### PR TITLE
feat: Enterprise Execution Handoff (GSD & MissionForge)

### DIFF
--- a/course.html
+++ b/course.html
@@ -235,7 +235,8 @@ pre,code{white-space:pre-wrap;word-break:break-word;overflow-x:hidden}
       <button class="nav-dot" data-target="module-6" aria-label="STRIDE Security"></button>
       <button class="nav-dot" data-target="module-7" aria-label="Konfiguration & Extensions"></button>
       <button class="nav-dot" data-target="module-8" aria-label="Kompletter Durchlauf"></button>
-      <button class="nav-dot" data-target="module-9" aria-label="Quiz & Abschluss"></button>
+      <button class="nav-dot" data-target="module-9" aria-label="Execution & Handoff"></button>
+      <button class="nav-dot" data-target="module-10" aria-label="Quiz & Abschluss"></button>
     </div>
   </div>
 </nav>
@@ -1072,11 +1073,59 @@ pre,code{white-space:pre-wrap;word-break:break-word;overflow-x:hidden}
   </div>
 </section>
 
-<!-- ========== MODULE 9: QUIZ & ABSCHLUSS ========== -->
-<section class="module" id="module-9" style="background:var(--color-bg)">
+<!-- ========== MODULE 9: EXECUTION & HANDOFF ========== -->
+<section class="module" id="module-9" style="background:var(--color-bg-warm)">
   <div class="module-content">
     <header class="module-header animate-in">
       <span class="module-number">09</span>
+      <h1 class="module-title">Execution & Handoff</h1>
+      <p class="module-subtitle">Enterprise-Ready Execution: SpecForge 🤝 GSD & MissionForge</p>
+    </header>
+
+    <section class="screen animate-in">
+      <h2 class="screen-heading">Die Spec ist fertig — was nun?</h2>
+      <p>SpecForge generiert audit-sichere Specs (Phase 1). Um diese Anforderungen nun in echten Code oder Aktionen umzuwandeln (Phase 2), gibt es zwei hochspezialisierte Ausführungspfade, die nahtlos in das <strong>Enterprise Skill Governance Framework</strong> integrieren.</p>
+
+      <div class="pattern-cards">
+        <div class="pattern-card">
+          <div class="pattern-header"><div class="pattern-type">Weg A: Terminal-Execution</div></div>
+          <p><strong>Get Shit Done (GSD)</strong></p>
+          <p>Ideal für massive Code-Änderungen. GSD läuft in der CLI (z.B. Claude Code), konsumiert die <code>spec.md</code> und arbeitet sie in isolierten 200k-Token-Subagenten ab.</p>
+          <ul style="list-style:none; padding:0; margin-top:1rem; font-size:0.9rem;">
+            <li>✅ Parallele Agenten-Ausführung</li>
+            <li>✅ Saubere, atomare Git-Commits</li>
+            <li>✅ Kein <em>Context Rot</em> bei großen Features</li>
+          </ul>
+        </div>
+        
+        <div class="pattern-card">
+          <div class="pattern-header"><div class="pattern-type">Weg B: In-Chat-Execution</div></div>
+          <p><strong>MissionForge & TaskPulse</strong></p>
+          <p>Ideal für komplexe Workflows direkt im Chat. Spawnt eine ganze Agenten-Company (Planung, Ausführung, QS). Jeder Sub-Agent erhält spezifische Tasks basierend auf den REQ-IDs aus SpecForge.</p>
+          <ul style="list-style:none; padding:0; margin-top:1rem; font-size:0.9rem;">
+            <li>✅ Komplett im Chat-Interface</li>
+            <li>✅ Nutzt TaskPulse-Protokolle (CMDB/ITIL konform)</li>
+            <li>✅ Hierarchische Agenten-Delegation</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="callout callout-info" style="margin-top:var(--space-6)">
+        <div class="callout-icon">📋</div>
+        <div class="callout-content">
+          <strong class="callout-title">ITIL & Governance Compliance</strong>
+          <p>Sowohl GSD als auch MissionForge hinterlassen standardisierte Ausführungsprotokolle (z.B. via TaskPulse-Integration). So erfüllt die gesamte Wertschöpfungskette (vom Jira-Ticket zur Spec bis zum Git-Commit) die strengsten Auditing-Anforderungen des Skill Governance Frameworks.</p>
+        </div>
+      </div>
+    </section>
+  </div>
+</section>
+
+<!-- ========== MODULE 10: QUIZ & ABSCHLUSS ========== -->
+<section class="module" id="module-10" style="background:var(--color-bg)">
+  <div class="module-content">
+    <header class="module-header animate-in">
+      <span class="module-number">10</span>
       <h1 class="module-title">Teste dein Wissen</h1>
       <p class="module-subtitle">Kannst du das Gelernte anwenden?</p>
     </header>

--- a/index.html
+++ b/index.html
@@ -539,6 +539,54 @@ Gherkin-Szenarien ─── Testfall-Ableitung ─── Testabdeckungsmatrix �
     </div>
   </section>
 
+  <!-- Handoff & Execution: GSD & MissionForge -->
+  <section style="background:var(--color-bg-warm);">
+    <div class="container">
+      <h2>Der Execution-Handoff: SpecForge 🤝 Get Shit Done & MissionForge</h2>
+      <p style="text-align:center; color:var(--text-muted); margin-bottom:32px;">
+        SpecForge generiert makellose, audit-sichere Specs. Aber wer baut sie? Hier kommen die Execution-Pipelines ins Spiel.
+      </p>
+      
+      <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(300px, 1fr)); gap:24px; margin-bottom:32px;">
+        <!-- Get Shit Done (GSD) -->
+        <div class="feature-card">
+          <div class="feature-icon">💻</div>
+          <h3>Weg A: Get Shit Done (GSD)</h3>
+          <p class="feature-desc">
+            <strong>Für massive Code-Änderungen im Terminal.</strong><br>
+            GSD nimmt die SpecForge <code>spec.md</code> entgegen, zerlegt sie in atomare Agenten-Pläne und schreibt parallel Code in frischen, isolierten 200k-Token-Fenstern. Verhindert <i>Context Rot</i> und pusht saubere Git-Commits. Ideal für die Claude Code CLI.
+          </p>
+          <p style="font-size:0.9rem; margin-top:12px; border-top:1px solid var(--color-border); padding-top:12px;">
+            <code>/gsd:plan-phase</code> ➡️ <code>/gsd:execute-phase</code>
+          </p>
+        </div>
+
+        <!-- MissionForge -->
+        <div class="feature-card">
+          <div class="feature-icon">🏢</div>
+          <h3>Weg B: MissionForge & TaskPulse</h3>
+          <p class="feature-desc">
+            <strong>Für komplexe Agenten-Orchestrierung im Chat.</strong><br>
+            Spawnt eine In-Chat-Company mit Planung, Ausführung und Verifikation. Jeder Sub-Agent erhält spezifische Tasks basierend auf den REQ-IDs aus SpecForge. Führt TaskPulse-Protokolle – voll kompatibel zum Enterprise Skill Governance Framework.
+          </p>
+          <p style="font-size:0.9rem; margin-top:12px; border-top:1px solid var(--color-border); padding-top:12px;">
+            <em>"Spawne Company basierend auf spec.md"</em>
+          </p>
+        </div>
+      </div>
+
+      <div class="callout callout-info">
+        <div class="callout-icon">🏛️</div>
+        <div class="callout-content">
+          <strong class="callout-title">Enterprise Governance Ready</strong>
+          <p>
+            SpecForge, MissionForge und GSD integrieren nahtlos in das <strong>Skill Governance Framework</strong>. SpecForge erzeugt ITIL/CMDB-konforme Anforderungen (Block A-F), und die Ausführungswerkzeuge hinterlassen pflichtgemäße Ausführungsprotokolle (TaskPulse) für das QA-Audit.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- Methodische Grundlagen -->
   <section>
     <div class="container">

--- a/references/templates/spec-template.md
+++ b/references/templates/spec-template.md
@@ -42,12 +42,13 @@ Danach: Pyramid Principle — max. 3 Schlüsselargumente als Stützen. Kein Tech
 |-------|----------|---------|
 | ... | ... | Hoch/Mittel/Gering |
 
-## 5. User Stories
+## 5. User Stories & Requirements
 
 ### [SF-XXX-001] [Titel]
 
 **Typ**: User Story | Technical Story | Enabler
 **Priorität**: MoSCoW: Must | Should | Could | Won't
+**REQ-ID**: [REQ-001] ← Wichtig für MissionForge Task-Generierung
 **Spec-First Steps**: [1,2,3,4,6,7]
 
 #### Story
@@ -69,7 +70,13 @@ Scenario: [Edge Case / Fehlerfall]
   When [Aktion]
   Then [Erwartetes Ergebnis]
 
-#### KRITIS-NFRs
+#### Execution Context (Für GSD & TaskPulse)
+- **Files/Components affected**: [src/components/..., api/...]
+- **Execution Action**: [Kurze maschinenlesbare Handlungsanweisung für GSD/Agents]
+- **Verification Command**: [Shell-Command oder curl zum Testen, z.B. `npm test -- -t SF-XXX-001`]
+
+#### KRITIS-NFRs & Governance
+**ITIL/CMDB Impact:** [High/Medium/Low - welche Services sind betroffen?]
 [Relevante Kategorien aus checklists/kritis-nfr.md]
 
 #### STRIDE-Bewertung
@@ -139,6 +146,8 @@ Dieses Modell beschreibt die Fachdomäne in der Sprache der Stakeholder. Technis
 
 - [ ] Alle User Stories haben EARS-Formulierung
 - [ ] Jede Story hat ≥2 Gherkin-Szenarien
+- [ ] Execution Context (Action & Verify Command) ist für GSD/Agents definiert
+- [ ] REQ-IDs für MissionForge Task-Generierung vergeben
 - [ ] NFR-Kategorien vollständig geprüft
 - [ ] STRIDE für security-relevante Stories durchgeführt
 - [ ] Keine vagen Begriffe ohne Quantifizierung


### PR DESCRIPTION
This PR adds the dual-execution handoff integrating **Get Shit Done (GSD)** and **MissionForge/TaskPulse** into the SpecForge documentation and templates. 

- Added 'Weg A (GSD)' and 'Weg B (MissionForge)' to the Workflow in `index.html`.
- Added a new Module 09 (Execution & Handoff) to the interactive training course (`course.html`).
- Optimized `spec-template.md` with an 'Execution Context' block for GSD, explicit REQ-IDs for MissionForge, and Governance/ITIL compliance (impact check).

This ensures SpecForge acts as a perfect Requirement Engineer (Phase 1) for the Enterprise Skill Governance Framework, producing specs directly consumable by these execution engines.

Co-Authored-By: Craft Agent <agents-noreply@craft.do>