### PR TITLE
Blockierende Fehler beheben

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -238,7 +238,7 @@ Referenzdateien sind in zwei Kategorien eingeteilt:
 
 **Nicht gelistete Pfade:** Ein `references/`-Pfad außerhalb von `references/custom/`, der in keiner der beiden Listen steht (etwa die Modul-Dateien der Dispatch-Tabelle), gilt als Core. Fehlt er, wird das für den Modus, der ihn lädt, wie KRITISCH behandelt.
 
-**Ausnahme innerhalb von `references/custom/`:** Dateien, die eine vorhandene `manifest.md` unter `Enthaltene Checklisten` auflistet, gehören fest zum Extension-Paket. Sie dürfen nicht fehlen; ihr Fehlen ist ein Paketfehler, kein offener Erweiterungspunkt.
+**Ausnahme innerhalb von `references/custom/`:** Ein `@paket/`, das mitgeliefert wird, ist kein offener Erweiterungspunkt. Jeder Pfad, der in ein vorhandenes Paket zeigt, muss dort existieren, ebenso jede Datei, die dessen `manifest.md` unter `Enthaltene Checklisten` auflistet. Fehlt eine davon, ist das ein Paketfehler. Verweise auf Pakete, die nicht mitgeliefert werden, bleiben Erweiterungspunkte.
 
 **Fehlerfall-Verhalten:**
 - KRITISCHE Referenz fehlt → Gate FAIL mit Fehlermeldung: `"[Datei] nicht gefunden — Prüfung nicht möglich. Bitte references/-Ordner prüfen."`

--- a/SKILL.md
+++ b/SKILL.md
@@ -232,8 +232,13 @@ Referenzdateien sind in zwei Kategorien eingeteilt:
 **OPTIONAL (Fehlen = Skip mit Warnung):**
 - `references/checklists/stride-guide.md` — STRIDE übersprungen (außer KRITIS: dort KRITISCH)
 - `references/checklists/kritis-nfr.md` — KRITIS-NFRs übersprungen (außer KRITIS-Profil: dort KRITISCH)
-- `references/custom/*.md` — Custom-Checks übersprungen
+- `references/custom/*.md` und `references/custom/@*/**/*.md` — Custom-Checks übersprungen
 - `references/conventions/folder-convention.md` — Folder-Check übersprungen
+- Jeder weitere Pfad unterhalb `references/custom/` — noch nicht angelegter Erweiterungspunkt, Skip mit Warnung
+
+**Nicht gelistete Pfade:** Ein `references/`-Pfad außerhalb von `references/custom/`, der in keiner der beiden Listen steht (etwa die Modul-Dateien der Dispatch-Tabelle), gilt als Core. Fehlt er, wird das für den Modus, der ihn lädt, wie KRITISCH behandelt.
+
+**Ausnahme innerhalb von `references/custom/`:** Dateien, die eine vorhandene `manifest.md` unter `Enthaltene Checklisten` auflistet, gehören fest zum Extension-Paket. Sie dürfen nicht fehlen; ihr Fehlen ist ein Paketfehler, kein offener Erweiterungspunkt.
 
 **Fehlerfall-Verhalten:**
 - KRITISCHE Referenz fehlt → Gate FAIL mit Fehlermeldung: `"[Datei] nicht gefunden — Prüfung nicht möglich. Bitte references/-Ordner prüfen."`

--- a/SKILL.md
+++ b/SKILL.md
@@ -217,7 +217,7 @@ SpecForge ist an folgenden Stellen erweiterbar — ohne Änderung an Core-Dateie
 | **NFR-Kategorien** | Neue Kategorien in `references/custom/nfr-custom.md` | kritis-nfr.md (Core), Custom-Datei (Ergänzung) |
 | **Checklisten** | `references/custom/*.md` oder `@scope/`-Pakete | 05-checklist.md |
 
-**Ablageregel:** Jeder Erweiterungspunkt liegt unterhalb `references/custom/`. Alle übrigen `references/`-Pfade sind Core und müssen vorhanden sein. Nur so bleiben Erweiterungen bei Core-Updates erhalten und nur so lässt sich ein fehlender Core-Pfad maschinell von einem noch nicht angelegten Erweiterungspunkt unterscheiden.
+**Ablageregel:** Jeder Erweiterungspunkt liegt unterhalb `references/custom/`. Alle übrigen `references/`-Pfade sind Core und müssen im Repo vorhanden sein; wie ein Modus zur Laufzeit auf ein Fehlen reagiert, regelt der Abschnitt „Fehlerbehandlung bei fehlenden Referenzen“. Nur so bleiben Erweiterungen bei Core-Updates erhalten und nur so lässt sich ein fehlender Core-Pfad maschinell von einem noch nicht angelegten Erweiterungspunkt unterscheiden.
 
 ### Fehlerbehandlung bei fehlenden Referenzen
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -208,7 +208,7 @@ SpecForge ist an folgenden Stellen erweiterbar — ohne Änderung an Core-Dateie
 
 | Was | Wie erweitern | Wo dokumentiert |
 |-----|--------------|----------------|
-| **EARS-Patterns** | Neue Patterns in `references/checklists/ears-patterns-custom.md` definieren; Dispatcher prüft Core + Custom | ears-syntax.md (Core), Custom-Datei (Ergänzung) |
+| **EARS-Patterns** | Neue Patterns in `references/custom/ears-patterns-custom.md` definieren; Dispatcher prüft Core + Custom | ears-syntax.md (Core), Custom-Datei (Ergänzung) |
 | **Profile** | Neues Profil in specforge.json als `profile_custom`-Objekt mit `base` (KRITIS/Standard/Startup) + `overrides` | specforge.json |
 | **Anti-Patterns** | AP-08+ in `references/custom/anti-patterns-custom.md`; Format identisch zu AP-01–AP-08 | enforcement-engine.md (Core), Custom-Datei (Ergänzung) |
 | **Golden Principles** | GP-11+ in `references/custom/golden-principles-custom.md`; `active_gps` in specforge.json erweitern | golden-principles.md (Core), Custom-Datei (Ergänzung) |
@@ -216,6 +216,8 @@ SpecForge ist an folgenden Stellen erweiterbar — ohne Änderung an Core-Dateie
 | **Review-Rollen** | Neue Rollen in `references/custom/@team-review-rollen/` | 06-stakeholder-sim.md |
 | **NFR-Kategorien** | Neue Kategorien in `references/custom/nfr-custom.md` | kritis-nfr.md (Core), Custom-Datei (Ergänzung) |
 | **Checklisten** | `references/custom/*.md` oder `@scope/`-Pakete | 05-checklist.md |
+
+**Ablageregel:** Jeder Erweiterungspunkt liegt unterhalb `references/custom/`. Alle übrigen `references/`-Pfade sind Core und müssen vorhanden sein. Nur so bleiben Erweiterungen bei Core-Updates erhalten und nur so lässt sich ein fehlender Core-Pfad maschinell von einem noch nicht angelegten Erweiterungspunkt unterscheiden.
 
 ### Fehlerbehandlung bei fehlenden Referenzen
 

--- a/references/01-specify.md
+++ b/references/01-specify.md
@@ -151,7 +151,7 @@ SpecForge prüft diese Checkliste und gibt ein Pass/Fail-Ergebnis aus:
 
 | Erweiterungspunkt | Wie | Wo |
 |-------------------|-----|-----|
-| Neue EARS-Patterns | `references/checklists/ears-patterns-custom.md` | Custom Extension |
+| Neue EARS-Patterns | `references/custom/ears-patterns-custom.md` | Custom Extension |
 | Neue Anti-Patterns | AP-08+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
 | Neue NFR-Kategorien | `references/custom/nfr-custom.md` | Custom Extension |
 | Branchenspezifische Checklisten | `references/custom/@branche-compliance/` | Custom Extension |

--- a/references/09-discover.md
+++ b/references/09-discover.md
@@ -170,7 +170,7 @@ Nach G4-RE: Übergang in Forward-Path ab G2 (Clarify) oder G3 (Plan).
 | Neue Anti-Patterns | AP-08+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
 | Branchenspezifische Discovery-Checklisten | `references/custom/@branche-compliance/discovery-checks.md` | Custom Extension |
 | Neue 5W-Dimensionen | 6W+ in `references/custom/5w-custom.md` (z.B. WIEVIEL für Skalierung) | Custom Extension |
-| Neue EARS-Patterns | `references/checklists/ears-patterns-custom.md` | Custom Extension |
+| Neue EARS-Patterns | `references/custom/ears-patterns-custom.md` | Custom Extension |
 | Custom NFR-Kategorien | `references/custom/nfr-custom.md` | Custom Extension |
 
 ## Fehlerbehandlung

--- a/references/10-derive.md
+++ b/references/10-derive.md
@@ -136,7 +136,7 @@ Jeder Testfall muss auf genau ein Gherkin-Szenario oder eine NFR zurückverfolgb
 | Erweiterungspunkt | Wie | Wo |
 |-------------------|-----|-----|
 | Neue Testfall-Typen | Zusätzliche Typen in `references/custom/test-types-custom.md` | Custom Extension |
-| Branchenspezifische Tests | z.B. DORA-Art.-26-TLPT-Tests in `references/custom/@dora/test-derive-rules.md` | Custom Extension |
+| Branchenspezifische Tests | z.B. DORA-Art.-26-TLPT-Tests in `references/custom/@{regulierung}/test-derive-rules.md` | Custom Extension |
 | Custom Testdaten-Generatoren | Domänenspezifische Testdaten-Templates | Custom Extension |
 
 ## Fehlerbehandlung

--- a/scripts/check-references.py
+++ b/scripts/check-references.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Prueft die references/-Pfade, die SKILL.md und die Module nennen.
+
+Der Skill laedt Referenzdateien per Pfadangabe. Ohne Pruefung faellt ein
+Tippfehler oder eine geloeschte Datei erst in der Session auf, und dort nur
+als Text, den das Modell notfalls improvisiert.
+
+Geprueft werden drei Regeln aus SKILL.md, Abschnitt "Fehlerbehandlung bei
+fehlenden Referenzen":
+
+1. Ablageregel: Erweiterungspunkte liegen unterhalb references/custom/.
+   Jeder andere references/-Pfad ist Core und muss existieren.
+2. Die als KRITISCH gefuehrten Dateien muessen existieren. Die Liste wird aus
+   SKILL.md gelesen, nicht hier hartkodiert, damit beide nicht auseinander
+   laufen.
+3. Extension-Pakete: ein Paket references/custom/@name/, das im Repo liegt,
+   ist ausgeliefert. Jeder Pfad, der in dieses Paket zeigt, muss existieren,
+   ebenso alles, was seine manifest.md unter "Enthaltene Checklisten"
+   auffuehrt. Nur Pfade in nicht vorhandene Pakete und die flachen
+   references/custom/*.md duerfen fehlen.
+
+Quelldateien: SKILL.md und references/**/*.md.
+Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
+"""
+
+import os
+import re
+import sys
+
+# Pfad-Token im Fliesstext, in Tabellen und in Code-Fences.
+PATH_RE = re.compile(r"references/[A-Za-z0-9_@{}*./+-]+")
+# Zeichen, die haeufig direkt am Pfad kleben, ohne dazuzugehoeren.
+TRAILING = "`.,;:)\"'*_"
+# Alles mit Platzhaltern ist kein pruefbarer Pfad.
+PLACEHOLDER_RE = re.compile(r"[*{}]|\bNN\b")
+
+CUSTOM_PREFIX = "references/custom/"
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def source_files(root):
+    files = []
+    skill = os.path.join(root, "SKILL.md")
+    if os.path.isfile(skill):
+        files.append(skill)
+    ref_dir = os.path.join(root, "references")
+    for dirpath, dirnames, filenames in os.walk(ref_dir):
+        dirnames.sort()
+        for name in sorted(filenames):
+            if name.endswith(".md"):
+                files.append(os.path.join(dirpath, name))
+    return files
+
+
+def collect_paths(root, files):
+    """Gibt {pfad: [(datei, zeile), ...]} zurueck."""
+    found = {}
+    for path in files:
+        rel = os.path.relpath(path, root)
+        with open(path, encoding="utf-8") as handle:
+            for lineno, line in enumerate(handle, 1):
+                for match in PATH_RE.finditer(line):
+                    token = match.group(0).rstrip(TRAILING)
+                    if not token:
+                        continue
+                    found.setdefault(token, []).append((rel, lineno))
+    return found
+
+
+def read_critical(root):
+    """Liest die KRITISCH-Liste aus SKILL.md."""
+    skill = os.path.join(root, "SKILL.md")
+    critical = []
+    inside = False
+    with open(skill, encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if stripped.startswith("**KRITISCH"):
+                inside = True
+                continue
+            if inside:
+                if stripped.startswith("- `"):
+                    token = stripped.split("`")[1]
+                    critical.append(token)
+                elif stripped and not stripped.startswith("-"):
+                    break
+    return critical
+
+
+def shipped_package(root, token):
+    """Paketname, wenn der Pfad in ein im Repo vorhandenes @-Paket zeigt."""
+    rest = token[len(CUSTOM_PREFIX):]
+    if "/" not in rest:
+        return None
+    package = rest.split("/", 1)[0]
+    if not package.startswith("@"):
+        return None
+    if os.path.isdir(os.path.join(root, "references", "custom", package)):
+        return CUSTOM_PREFIX + package
+    return None
+
+
+def read_manifest_files(root):
+    """Sammelt die von Extension-Manifesten deklarierten Dateien."""
+    declared = []
+    custom_dir = os.path.join(root, "references", "custom")
+    if not os.path.isdir(custom_dir):
+        return declared
+    for entry in sorted(os.listdir(custom_dir)):
+        manifest = os.path.join(custom_dir, entry, "manifest.md")
+        if not os.path.isfile(manifest):
+            continue
+        inside = False
+        with open(manifest, encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    inside = "Enthaltene Checklisten" in stripped
+                    continue
+                if inside and stripped.startswith("- `"):
+                    token = stripped.split("`")[1]
+                    rel = os.path.join("references", "custom", entry, token)
+                    declared.append((rel.replace(os.sep, "/"),
+                                     os.path.relpath(manifest, root)))
+    return declared
+
+
+def main():
+    root = repo_root()
+    files = source_files(root)
+    found = collect_paths(root, files)
+
+    placeholders = []
+    non_files = []
+    core = []
+    extension = []
+
+    for token in sorted(found):
+        if PLACEHOLDER_RE.search(token):
+            placeholders.append(token)
+        elif not token.endswith(".md"):
+            non_files.append(token)
+        elif token.startswith(CUSTOM_PREFIX):
+            extension.append(token)
+        else:
+            core.append(token)
+
+    errors = []
+
+    missing_core = [t for t in core if not os.path.isfile(os.path.join(root, t))]
+    for token in missing_core:
+        where = ", ".join("%s:%d" % loc for loc in found[token][:3])
+        errors.append("Core-Pfad fehlt: %s (genannt in %s)" % (token, where))
+
+    critical = read_critical(root)
+    for token in critical:
+        if not os.path.isfile(os.path.join(root, token)):
+            errors.append("KRITISCH-Datei fehlt: %s (SKILL.md)" % token)
+        elif token.startswith(CUSTOM_PREFIX):
+            errors.append("KRITISCH-Datei liegt unter references/custom/, "
+                          "das widerspricht der Ablageregel: %s" % token)
+
+    declared = read_manifest_files(root)
+    for token, manifest in declared:
+        if not os.path.isfile(os.path.join(root, token)):
+            errors.append("Vom Manifest deklarierte Datei fehlt: %s (%s)"
+                          % (token, manifest))
+
+    for token in extension:
+        package = shipped_package(root, token)
+        if package and not os.path.isfile(os.path.join(root, token)):
+            where = ", ".join("%s:%d" % loc for loc in found[token][:3])
+            errors.append("Verweis in das ausgelieferte Paket %s zeigt auf eine "
+                          "Datei, die es dort nicht gibt: %s (genannt in %s)"
+                          % (package, token, where))
+
+    ext_present = [t for t in extension
+                   if os.path.isfile(os.path.join(root, t))]
+    ext_absent = [t for t in extension if t not in ext_present]
+
+    print("Quelldateien:            %d (SKILL.md + references/**/*.md)" % len(files))
+    print("Gefundene Pfad-Angaben:  %d eindeutig" % len(found))
+    print("  davon Platzhalter:     %d (uebersprungen)" % len(placeholders))
+    print("  davon keine .md-Datei: %d (uebersprungen)" % len(non_files))
+    print("Gepruefte Pfade:         %d" % (len(core) + len(extension)))
+    print("  Core (Pflicht):        %d, davon fehlend %d"
+          % (len(core), len(missing_core)))
+    print("  Erweiterungspunkte:    %d, davon angelegt %d, offen %d"
+          % (len(extension), len(ext_present), len(ext_absent)))
+    print("KRITISCH laut SKILL.md:  %d" % len(critical))
+    print("Manifest-Deklarationen:  %d" % len(declared))
+
+    if ext_absent:
+        print("")
+        print("Offene Erweiterungspunkte (dokumentiert, Fehlen erlaubt):")
+        for token in ext_absent:
+            print("  - %s" % token)
+
+    if errors:
+        print("")
+        print("FEHLER (%d):" % len(errors))
+        for message in errors:
+            print("  - %s" % message)
+        return 1
+
+    print("")
+    print("OK: alle Core-Pfade, KRITISCH-Dateien und Manifest-Angaben vorhanden.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Was geaendert wurde

Vier Commits auf `fix/welle-2`, alle im Themenkreis "tote Referenzpfade".

### 1. Erweiterungspunkt fuer EARS-Patterns nach `references/custom/` verschoben

`ears-patterns-custom.md` war als `references/checklists/ears-patterns-custom.md` dokumentiert, also im Core-Verzeichnis. SKILL.md fuehrt `references/checklists/` unter den Core-Referenzen ("nicht veraenderbar") und sichert Update-Festigkeit ausdruecklich nur fuer `references/custom/` zu. Eine dort angelegte Nutzerdatei waere beim naechsten Core-Update verschwunden, und die OPTIONAL-Regel `references/custom/*.md` traf auf sie nicht zu. Pfad in SKILL.md, `01-specify.md` und `09-discover.md` korrigiert und die Ablageregel in SKILL.md notiert.

### 2. Fehlerbehandlung auf alle Extension-Pfade ausgeweitet

Die OPTIONAL-Liste deckte nur `references/custom/*.md` ab, also die flache Ebene. Von den fehlenden Pfaden liegen sechs tiefer (`@branche-compliance/...`), fuer sie war kein Verhalten definiert. Die Modul-Dateien der Dispatch-Tabelle standen in keiner der beiden Kategorien. Glob auf `references/custom/*.md` + `references/custom/@*/**/*.md` erweitert, passend zur bereits vorhandenen Formulierung in der Checker-Tabelle, und zwei Regeln ergaenzt: nicht gelistete Core-Pfade zaehlen wie KRITISCH, und ein mitgeliefertes `@paket/` ist kein offener Erweiterungspunkt.

### 3. Beispielpfad in `10-derive.md` vom Paket @dora entkoppelt

Die Zeile nannte `references/custom/@dora/test-derive-rules.md` als Ablage fuer branchenspezifische Testregeln. @dora wird vom Repo ausgeliefert, fuehrt unter "Enthaltene Checklisten" aber nur `checklisten/dora-nfr.md` und listet unter Trigger-Modi die Modi 1, 4, 5, 6 und 7, nicht Modus 10. Der Verweis zeigte in ein ausgeliefertes Paket hinein auf eine Datei, die dessen eigenes Manifest nicht kennt. Jetzt `references/custom/@{regulierung}/test-derive-rules.md`, wie CONTRIBUTING-CHECKLISTS.md die Paketstruktur schreibt.

### 4. `scripts/check-references.py`

Liest alle `references/`-Pfade aus SKILL.md und den Modulen und prueft sie gegen die Regeln, die in SKILL.md stehen. Drei Pruefungen gehen ueber "Datei da?" hinaus:

- Die KRITISCH-Liste wird aus SKILL.md geparst statt im Skript hinterlegt, damit Text und Pruefung nicht auseinander laufen.
- Fuer jedes Extension-Paket mit `manifest.md` wird geprueft, ob die unter "Enthaltene Checklisten" genannten Dateien existieren.
- Zeigt ein Verweis in ein Paket, das im Repo liegt, muss die Datei dort existieren. Das ist der Regressionsschutz fuer den Fall aus Commit 3.

Nur Standardbibliothek, kein Framework, keine neue Abhaengigkeit. Exit 1 bei jedem Verstoss, damit es spaeter als CI-Schritt taugt.

## Warum

Der Ausgangsbefund lautete: 22 von 42 referenzierten `references/`-Pfaden existieren nicht. Die Zahl stimmt exakt. Die Schlussfolgerung traegt aber nicht: 20 der 22 stehen in Tabellen unter "## Erweiterbarkeit" mit der Spalte "Custom Extension", und SKILL.md erlaubt ihr Fehlen ausdruecklich ("OPTIONAL, Fehlen = Skip mit Warnung"). Sie anzulegen haette 20 leere Platzhalter erzeugt, sie zu entfernen haette die dokumentierte Erweiterbarkeit abgeschafft.

Die echten Defekte lagen an drei Raendern: ein Erweiterungspunkt im Core-Verzeichnis, eine Regel, die nur die flache Ebene abdeckte, und ein Verweis in ein ausgeliefertes Paket, das die Datei nicht kennt. Alle drei sind behoben. Der Rest ist jetzt maschinell als das erkennbar, was er ist.

## Wie geprueft

Skript im gruenen Fall:

```
Quelldateien:            24 (SKILL.md + references/**/*.md)
Gefundene Pfad-Angaben:  52 eindeutig
  davon Platzhalter:     8 (uebersprungen)
  davon keine .md-Datei: 4 (uebersprungen)
Gepruefte Pfade:         40
  Core (Pflicht):        19, davon fehlend 0
  Erweiterungspunkte:    21, davon angelegt 1, offen 20
KRITISCH laut SKILL.md:  4
Manifest-Deklarationen:  2

OK: alle Core-Pfade, KRITISCH-Dateien und Manifest-Angaben vorhanden.
```

Exit 0. Dazu drei Negativtests, jeweils mit anschliessendem Rueckbau und sauberem `git status`:

1. `references/checklists/ears-syntax.md` weggeschoben: Exit 1, zwei Fehler (Core-Pfad fehlt, KRITISCH-Datei fehlt), mit Fundstellen SKILL.md:176, SKILL.md:227, 01-specify.md:69.
2. `references/custom/@dora/checklisten/dora-nfr.md` weggeschoben: Exit 1, "Vom Manifest deklarierte Datei fehlt".
3. Alten Stand von `references/10-derive.md` zurueckgeholt: Exit 1, "Verweis in das ausgelieferte Paket references/custom/@dora zeigt auf eine Datei, die es dort nicht gibt", mit Fundstelle 10-derive.md:139.

Der dritte Test ist der wichtigste: er beweist, dass die Reparatur aus Commit 3 nicht stillschweigend zurueckfallen kann.

Zur Arithmetik: das Skript kommt auf 40 pruefbare Pfade statt 42, weil `references/custom/mode-NN-name.md` ein Muster mit Platzhalter ist und `@dora/test-derive-rules.md` durch die Reparatur zu `@{regulierung}/test-derive-rules.md` geworden ist. Beides wird als Muster uebersprungen.

## Was offen bleibt

- **Die zwei Schweregrad-Dialekte.** F-Stufen (F0-F5) gegen BLOCKER/MAJOR/MINOR. Fuenf Fachmodule sprechen ausschliesslich den alten Dialekt, drei mischen, eines hat gar keinen. Das ist eine Bedeutungsaenderung am Produkt und liegt als Vorschlag mit Zaehlung und Empfehlung bei, ohne Commit. Kurz: die F-Stufen sollten gewinnen, weil das Repo den anderen Dialekt an drei Stellen selbst "Legacy" nennt, und die Umstellung muss Pruefpunkt fuer Pruefpunkt laufen, weil das Mapping nur F4, F3 und F1 erreicht.
- **@dora haelt das eigene Schema nicht ein.** Spaltenname `DORA-Artikel` statt `Rechtsquelle` in sechs Tabellen, keine `_default`-Spalte in der Checklisten-Fassung der F-Stufen-Tabelle, 34-mal "F 4" mit Leerzeichen, F-Stufen-Tabelle doppelt gepflegt. Sollte behoben sein, bevor MaRisk oder PCI-DSS das Muster kopieren.
- **`references/checklists/kritis-nfr.md`** hat in keiner der sechs Tabellen eine Rechtsquellen-Spalte, obwohl das Schema sie als Pflicht fuehrt, und nutzt eine andere F-Stufen-Achse als die Extensions.
- **Kein CI-Workflow.** Das Skript laeuft, wird aber von nichts aufgerufen. Ein `.github/workflows/`-Eintrag ist ein Einzeiler, war aber nicht Teil des Auftrags.
- **`references/custom/@dora/test-derive-rules.md`** ist bewusst nicht angelegt worden. Der Inhalt waere Regulatorik gewesen, die niemand geprueft hat.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk

## Nacharbeit nach der Abnahme

Die neue Ablageregel widersprach dreizehn Zeilen weiter der unveraenderten OPTIONAL-Liste:
`stride-guide.md`, `kritis-nfr.md` und `folder-convention.md` standen gleichzeitig unter
"muss vorhanden sein" und unter "Fehlen gleich Skip mit Warnung". Jetzt trennt der Text
zwischen der Frage, was im Repo liegen muss, und der Frage, wie ein Modus zur Laufzeit auf
ein Fehlen reagiert.

## Was bewusst offen bleibt

- `scripts/check-references.py` traegt die Pauschalformel im Kommentar weiter.
- Der Vorschlag zur Vereinheitlichung der zwei Schweregrad-Dialekte liegt als eigener Text
  vor und ist nicht Teil dieses PR. Er aendert die Bedeutung des Produkts und braucht eine
  Entscheidung, keinen stillen Commit.


---
Teil von Welle 2 des Haerteplans: erst lauffaehig, dann sichtbar. Jede Aenderung wurde von einem zweiten Durchgang abgenommen, der die Pruefungen selbst wiederholt hat.
