### PR TITLE
CI sichtbar machen und Aussagen richtigstellen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  konsistenz:
+    name: Konsistenzpruefung
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository auschecken
+        uses: actions/checkout@v4
+
+      - name: Python bereitstellen
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Referenzpfade pruefen
+        run: python scripts/check-references.py
+
+      - name: SKILL.md-Frontmatter pruefen
+        run: python scripts/check-frontmatter.py
+
+      - name: Checklisten und Manifeste pruefen
+        run: python scripts/check-checklists.py
+
+      - name: Zahlenangaben in README und Landingpage pruefen
+        run: python scripts/check-docs-numbers.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Versionsgeschichte von SpecForge. Die Einträge beschreiben den Stand der
+jeweiligen Version und werden nicht rückwirkend geändert.
+
+Schema und Geltungsbereich der Versionen stehen im [README](README.md),
+Abschnitt Versionierung.
+
+---
+
+| Version | Datum | Änderung |
+|---------|-------|---------|
+| 1.0 | 2025-10 | Initial: Specify, Plan, Tasks, Review, Stakeholder-Sim, Management |
+| 2.0 | 2026-03 | +Clarify, +Analyze, +Checklist, +Research, +Quickstart. SpecKit v3 Alignment. RE Butler entfernt. Single-File-Architektur. |
+| 2.1 | 2026-03 | +Phase 0 (Cynefin + Impact Mapping), 15 methodische Frameworks mit Aktivieren-Eingrenzen-Prüfen-Muster, Sokratische Klärung, MECE-Analyse, Devil's Advocate + Steelmanning, Morphological Box + Pugh Matrix, DDD-Datenmodell, BLUF-Zusammenfassungen. |
+| 2.2 | 2026-03 | +Modus 9 Discover (Bestandsdokumentation & Reverse Spec). Zwei verpflichtende QS-Schleifen: Vollständigkeit + Konsistenz/Stringenz. Rückwärts-Validierung. discovery-protocol.md und migration-delta.md als neue Artefakte. |
+| 2.3 | 2026-03 | +Anhang I Enforcement Engine: State Machine (INIT→COMPLETE), Phase Gates G0–G8, Skip-Protokoll, Vage-Begriffe-Scanner, Anti-Pattern-Erkennung. +5W-Pflichtblock für Reverse-Engineering. +Artefakt-Vollständigkeits-Check. +Session-Status-Anzeige. 21 Interaktions- + 26 Qualitätsregeln. |
+| 3.0 (v202-green) | 2026-03 | **Architektur-Wechsel: Single-File → Multi-File.** Orchestrator (SKILL.md, 395 Zeilen) + 9 Fachmodule + 9 Support-Dateien = 19 Dateien, 3.143 Zeilen. Jedes Modul erhält standardisierte Sektionen: Stringenz-Regeln, Erweiterbarkeit, Fehlerbehandlung, GP-Mapping. Orchestrator mit Pre-Flight Checks, Profil-Resolution Cascade, Calendar Versioning, Audit Trail, Session-Retrospektive, 8 Built-in Extension Points. Deterministische Rollenauswahl (M06), GP-Score-Formel (M07), 7 Management-Funktionen (M08), QS-Loops mit Terminierung (M09). Autoresearch-optimiert: 600 Assertions, 6 Dimensionen, 68%→80% Score über 5 Iterationen. |
+| 3.1 | 2026-03 | **DORA-Integration & F-Stufen-System.** +F-Stufen (F0–F5) nach PrüfbV §27 ersetzen binäres Pass/Fail. +CONDITIONAL als dritter Gate-Ausgang (Risiko-Akzeptanz). +Perspektive als orthogonale Dimension zu Profil (Lieferkettenrolle). +Manifest-Auto-Detection für Extensions. +DORA-Extension (58 Prüfpunkte, 6 Kategorien, 3 Perspektiven). +BAIT-Stub (8 Prüfpunkte). +CONTRIBUTING-CHECKLISTS.md mit Schema, Validierung und Kandidatenliste. +Erweiterter Audit Trail mit F-Stufen und Perspektive. |
+| 3.2 | 2026-03 | **Qualitätserweiterungen aus RE-Skill-Analyse.** +AP-08 SOPHIST-Verletzung (Passiv, Negation, Generik, unvollständige Aufzählung, implizite Zeitangabe) mit SOPHIST-Blocklist. +`[Offen: ...]`-Marker für unvollständige Stories (F3 nach Clarify). +Story-Quality-Score (SQS) als numerische Qualitätsbewertung (0–5) in Review und Analyze. +Modus 10 Derive: Testfall-Ableitung aus Gherkin-Szenarien mit Testabdeckungsmatrix, 6 Testfall-Typen, Traceability. +MCP-Kontext-Pre-Flight in Specify für externe Quellen (Figma, GitHub, Confluence, Jira). |

--- a/CONTRIBUTING-CHECKLISTS.md
+++ b/CONTRIBUTING-CHECKLISTS.md
@@ -118,7 +118,12 @@ Die Spalte `_default` ist Pflicht und wird verwendet, wenn keine Perspektive ges
 
 ## 3. Validierung
 
-Bevor eine Extension als fertig gilt, muss sie diese 4-Schritte-Prüfung bestehen:
+Bevor eine Extension als fertig gilt, muss sie diese 4-Schritte-Prüfung bestehen.
+Die maschinell prüfbaren Punkte aus Schritt 1 bis 3 übernimmt `scripts/check-checklists.py`:
+eindeutige IDs, lückenlose Nummerierung, gültige F-Stufen, Pflicht-Abschnitte im Manifest,
+`_default`-Spalte und Übereinstimmung von Manifest-Angabe und Checkliste. Das Skript läuft in
+der CI bei jedem Push und Pull Request auf `main`, lokal mit `python3 scripts/check-checklists.py`.
+Schritt 4 bleibt Handarbeit in der Session.
 
 ### Schritt 1: Schema-Prüfung
 

--- a/README.md
+++ b/README.md
@@ -314,13 +314,13 @@ specforge/
 
 ### Was die Fachmodule enthalten (Standard-Sektionen)
 
-Die 10 Fachmodule folgen weitgehend derselben Struktur. In allen zehn stehen Fehlerbehandlung und Erzeugte Artefakte, bei den übrigen Sektionen nennt die Tabelle die Ausnahmen:
+Die 10 Fachmodule folgen weitgehend derselben Struktur. Wo eine Sektion fehlt oder anders heißt, sagt es die Tabelle:
 
 | Sektion | Beschreibung |
 |---------|-------------|
 | Profil-Steuerung | KRITIS/Standard/Startup-spezifisches Verhalten. Eigene Sektion in acht Modulen; `01-specify.md` behandelt die Profilwahl als Ablaufschritt, `02-clarify.md` unter „Wann Pflicht vs. Optional (profilabhängig)“ |
-| Ablauf (deterministisch) | Nummerierte Phasen mit konkreten Schritten |
-| Output-Template | Markdown-Template für erzeugte Artefakte |
+| Ablauf (deterministisch) | Nummerierte Phasen mit konkreten Schritten. Eigene Überschrift in fünf Modulen; `01-specify.md`, `02-clarify.md`, `03-plan.md` und `10-derive.md` gliedern direkt nach Phasen, `08-management.md` nach Funktionen |
+| Output-Template | Markdown-Template für erzeugte Artefakte, in allen zehn Modulen vorhanden. Eigene Sektion „Output: …“ nur in `04-analyze.md`, `05-checklist.md`, `06-stakeholder-sim.md` und `07-review.md` |
 | Stringenz-Regeln (Enforcement) | Tabellarische Regeln mit Schweregraden. Fehlt in `04-analyze.md` und `05-checklist.md` |
 | Erweiterbarkeit | Custom-Extension-Punkte mit Pfaden. Fehlt in `04-analyze.md` und `05-checklist.md` |
 | Fehlerbehandlung | Tabellarische Edge-Case-Behandlung, vier bis neun Fälle je nach Modul |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Neu in v3: Brownfield-vs-Greenfield-Erkennung, Explore-Phase mit parallelen Arch
 "Erstelle eine DSGVO-Compliance-Checklist."
 ```
 
-4 Checklist-Typen: Spec-Readiness (Typ A), Compliance (Typ B), Security (Typ C), Domain-spezifisch (Typ D). Wiederverwendbare Prüflisten — "Unit Tests für Prosa".
+4 Checklist-Typen: Spec-Readiness (Typ A), Plan-Readiness (Typ B), Custom (Typ C), Domain (Typ D). Wiederverwendbare Prüflisten — "Unit Tests für Prosa".
 
 ### Modus 6: Stakeholder-Simulation
 

--- a/README.md
+++ b/README.md
@@ -359,11 +359,11 @@ SpecForge ist Prompt-Text, kein Programm. Daraus folgen Grenzen, die keine Versi
 
 Offen, in dieser Reihenfolge:
 
-1. **Schweregrade vereinheitlichen** — BLOCKER/MAJOR/MINOR in den Modulen auf F-Stufen umstellen, damit derselbe Mangel in jedem Modus dieselbe Stufe bekommt.
-2. **Beispiel-Spezifikationen ins Repo** — hier liegen nur Templates und Eingabe-Prompts, keine fertige Spec, an der sich ein Ergebnis messen ließe.
-3. **`@bait` vervollständigen** — vom Stub auf die Kapitel der BaFin-Rundschreiben 10/2017 (BA) und 10/2021 (BA).
-4. **Weitere Regulierungen** — MaRisk, PCI-DSS 4.0, EnWG/IT-Sicherheitskatalog. Priorisierung in [CONTRIBUTING-CHECKLISTS.md](CONTRIBUTING-CHECKLISTS.md), Abschnitt 5.
-5. **Release mit Tag** — damit eine Version zitierbar wird und die Landingpage auf etwas Festes zeigen kann.
+1. **Schweregrade vereinheitlichen:** BLOCKER/MAJOR/MINOR in den Modulen auf F-Stufen umstellen, damit derselbe Mangel in jedem Modus dieselbe Stufe bekommt.
+2. **Beispiel-Spezifikationen ins Repo:** hier liegen nur Templates und Eingabe-Prompts, keine fertige Spec, an der sich ein Ergebnis messen ließe.
+3. **`@bait` vervollständigen:** vom Stub auf die Kapitel der BaFin-Rundschreiben 10/2017 (BA) und 10/2021 (BA).
+4. **Weitere Regulierungen:** MaRisk, PCI-DSS 4.0, EnWG/IT-Sicherheitskatalog. Priorisierung in [CONTRIBUTING-CHECKLISTS.md](CONTRIBUTING-CHECKLISTS.md), Abschnitt 5.
+5. **Release mit Tag:** damit eine Version zitierbar wird und die Landingpage auf etwas Festes zeigen kann.
 6. **Englische Fassung** des Payloads.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SpecForge — Specs schmieden, nicht schreiben
+
 **Spec-Driven Requirements Engineering als KI-Skill für Claude.**
 
 SpecForge kombiniert [GitHub Spec Kit](https://github.com/github/spec-kit), Harness-Patterns (Golden Principles, Spec-First Chain, STRIDE, Folder Convention) mit EARS-Syntax, Gherkin Acceptance Criteria und automatischen KRITIS/NIS2-NFRs zu einem modularen, selbsttragenden Skill-System.
@@ -183,6 +184,15 @@ Neu in v3: 7 Management-Funktionen (Traceability Matrix, SFC-Audit, ExecPlan-Üb
 
 Reverse Spec: Vom bestehenden System rückwärts zur vollwertigen spec.md. Zwei verpflichtende QS-Schleifen — erst Vollständigkeitsprüfung, dann Konsistenz- und Stringenzprüfung. Neu in v3: 5W-Analyse als Pflichtblock, QS-Loops mit max. 5 Iterationen und Terminierung, eigene RE Gates (G0-RE bis G4-RE).
 
+### Modus 10: Derive — Testfälle aus Acceptance Criteria
+
+```
+"Leite Testfälle aus den Gherkin-Szenarien ab."
+"Erstelle die Testabdeckungsmatrix für dieses Feature."
+```
+
+Aus jedem Gherkin-Szenario wird ein Testfall `[Story-ID]-TC[NNN]` mit Vorbedingung, Aktion, erwartetem Ergebnis und Testdaten. Dazu die Testabdeckungsmatrix und eine Traceability-Prüfung Story zu Testfall. 6 Testfall-Typen, Pflicht-Scope je Profil.
+
 ---
 
 ## Workflow
@@ -256,49 +266,53 @@ design/                ← Wireframes, Datenmodelle, Diagramme
 
 ## Skill-Architektur
 
-SpecForge v3 ist als **Multi-File-Skill** aufgebaut — ein Orchestrator (SKILL.md) dispatcht zu 9 Fachmodulen und 9 Support-Dateien in einer `references/`-Verzeichnisstruktur:
+SpecForge ist als **Multi-File-Skill** aufgebaut: ein Orchestrator (`SKILL.md`) dispatcht zu 10 Fachmodulen und 13 Support-Dateien unter `references/`.
 
 ```
 specforge/
-├── SKILL.md                              (395 Zeilen — Orchestrator)
+├── SKILL.md                          Orchestrator: Dispatch, Gates, Pre-Flight
 └── references/
-    ├── 01-specify.md                     (163 Zeilen)
-    ├── 02-clarify.md                     (159 Zeilen)
-    ├── 03-plan.md                        (242 Zeilen)
-    ├── 04-analyze.md                     (141 Zeilen)
-    ├── 05-checklist.md                   (132 Zeilen)
-    ├── 06-stakeholder-sim.md             (155 Zeilen)
-    ├── 07-review.md                      (173 Zeilen)
-    ├── 08-management.md                  (199 Zeilen)
-    ├── 09-discover.md                    (215 Zeilen)
+    ├── 01-specify.md                 Modus 1: Specify
+    ├── 02-clarify.md                 Modus 2: Clarify
+    ├── 03-plan.md                    Modus 3: Plan & Tasks
+    ├── 04-analyze.md                 Modus 4: Analyze
+    ├── 05-checklist.md               Modus 5: Checklist
+    ├── 06-stakeholder-sim.md         Modus 6: Stakeholder-Simulation
+    ├── 07-review.md                  Modus 7: Review
+    ├── 08-management.md              Modus 8: Management & Traceability
+    ├── 09-discover.md                Modus 9: Discover
+    ├── 10-derive.md                  Modus 10: Derive
     ├── checklists/
-    │   ├── ears-syntax.md                (79 Zeilen)
-    │   ├── golden-principles.md          (100 Zeilen)
-    │   ├── kritis-nfr.md                (95 Zeilen)
-    │   └── stride-guide.md              (127 Zeilen)
+    │   ├── ears-syntax.md
+    │   ├── golden-principles.md
+    │   ├── kritis-nfr.md             41 Prüfpunkte, KRITIS/NIS2
+    │   └── stride-guide.md
     ├── templates/
-    │   ├── spec-template.md              (181 Zeilen)
-    │   └── constitution-template.md      (154 Zeilen)
+    │   ├── spec-template.md
+    │   └── constitution-template.md
     ├── conventions/
-    │   ├── folder-convention.md          (105 Zeilen)
-    │   └── spec-first-chain.md           (102 Zeilen)
-    └── enforcement/
-        └── enforcement-engine.md         (226 Zeilen)
+    │   ├── folder-convention.md
+    │   └── spec-first-chain.md
+    ├── enforcement/
+    │   └── enforcement-engine.md
+    └── custom/
+        ├── @dora/                    manifest.md + 58 Prüfpunkte
+        └── @bait/                    manifest.md + 8 Prüfpunkte, Stub
 ```
 
-**19 Dateien, 3.143 Zeilen total.**
+**Skill-Payload: 24 Dateien.** Orchestrator + 10 Fachmodule + 13 Support-Dateien.
 
 ### Warum Multi-File?
 
-- **Separation of Concerns** — Orchestrator bleibt kompakt (395 Zeilen), Module werden nur bei Bedarf geladen
+- **Separation of Concerns** — Orchestrator bleibt kompakt, Module werden nur bei Bedarf geladen
 - **Wartbarkeit** — einzelne Module unabhängig aktualisierbar
 - **Erweiterbarkeit** — neue Modi, Checklisten oder Profile über `references/custom/` hinzufügbar
 - **Audit-freundlich** — jede Datei unabhängig bewertbar und testbar
-- **Context-Window-effizient** — statt 3.143 Zeilen auf einmal lädt Claude nur Orchestrator + benötigtes Modul
+- **Context-Window-effizient** — Claude lädt Orchestrator plus benötigtes Modul, nicht den ganzen Payload
 
 ### Was jedes Modul enthält (Standard-Sektionen)
 
-Jedes der 9 Fachmodule (M01–M09) folgt einer einheitlichen Struktur:
+Jedes der 10 Fachmodule (M01–M10) folgt einer einheitlichen Struktur:
 
 | Sektion | Beschreibung |
 |---------|-------------|
@@ -318,7 +332,7 @@ Jedes der 9 Fachmodule (M01–M09) folgt einer einheitlichen Struktur:
 | Pre-Flight Checks | specforge.json laden, Profil-Resolution, Referenz-Verfügbarkeit |
 | Dispatch-Tabelle | Modus → Modul-Mapping mit Trigger-Keywords |
 | Profil-Resolution Cascade | CLI-Flag → specforge.json → Nutzer-Frage → Standard |
-| Calendar Versioning | `v<YYMM>` mit Suffix (`-green`, `-yellow`) für Audit-Status |
+| Artefakt-Versionierung | `YYYY.MM.DD.N` im `version:`-Feld jedes erzeugten Artefakts |
 | Session-Retrospektive | Automatische Zusammenfassung am Session-Ende |
 | Erweiterbarkeit | 8 Built-in Extension Points (EARS, Profile, APs, GPs, Modi, ...) |
 | Fehlerbehandlung | KRITISCH vs. OPTIONAL Referenzen mit spezifischem Verhalten |
@@ -326,140 +340,51 @@ Jedes der 9 Fachmodule (M01–M09) folgt einer einheitlichen Struktur:
 
 ---
 
-## Eigenen Skill nach diesem Muster erstellen
+## Grenzen
 
-SpecForge kann als Blaupause für eigene Skills dienen. Hier die Methodik:
+SpecForge ist Prompt-Text, kein Programm. Daraus folgen Grenzen, die keine Version wegräumt:
 
-### 1. Frontmatter definieren
-```yaml
----
-name: MeinSkill
-description: Kurzbeschreibung mit Trigger-Keywords. Verwende diesen Skill
-  IMMER bei: keyword1, keyword2, keyword3. Auch bei "natürlichsprachlicher
-  Trigger", "weiterer Trigger".
----
-```
-
-**Regeln für gute Trigger:**
-- Technische Begriffe UND natürlichsprachliche Formulierungen
-- "Verwende diesen Skill IMMER bei:" signalisiert Claude den Aktivierungszeitpunkt
-- "Auch bei:" für indirekte Trigger ("prüfe meine X", "was fehlt bei Y")
-
-### 2. Session-Isolation festlegen
-
-Entscheide: Darf der Skill auf Memories/Vorwissen zugreifen oder ist jede Session ein Blank Slate?
-
-```markdown
-## Wissensquellen
-MeinSkill arbeitet ausschließlich mit:
-1. Session-Kontext
-2. Eigenrecherche via Web Search
-3. Skill-eigene Referenzen
-```
-
-### 3. Modi definieren
-
-Jeder Modus hat:
-- **Trigger:** Woran erkennt der Skill, dass dieser Modus gemeint ist?
-- **Phasen:** Welche Schritte werden durchlaufen?
-- **Artefakte:** Was wird erzeugt?
-- **Abschlusskriterium:** Wann ist der Modus fertig?
-
-```markdown
-### Modus N: [Name]
-**Trigger:** [Beschreibung]
-**Phase Na: [Schritt]**
-1. ...
-2. ...
-**Erzeugte Artefakte:**
-- ...
-```
-
-### 4. Output-Formate als Templates definieren
-
-Gib Claude exakte Templates mit Platzhaltern:
-
-```markdown
-## Output-Format: [Artefakt-Typ]
-\```markdown
-### [ID] [Titel]
-**Typ**: ...
-**Priorität**: ...
-#### Abschnitt
-[Inhalt]
-\```
-```
-
-### 5. Qualitätsregeln als enforceable Constraints
-
-Nicht "versuche X" sondern "X ist Pflicht":
-
-```markdown
-## Qualitätsregeln (immer aktiv)
-1. **Regel** — Enforcement-Beschreibung
-2. **Regel** — Enforcement-Beschreibung
-```
-
-### 6. Interaktionsregeln für Gesprächsführung
-
-```markdown
-## Interaktionsregeln
-1. Max. N Fragen pro Runde
-2. Nach [Aktion] einmal validieren
-3. Smarte Annahmen mit `[Annahme: ...]` kennzeichnen
-```
-
-### 7. Referenzen als separate Dateien
-
-Statt alles inline: Module in `references/` auslagern und per Dispatch-Tabelle referenzieren:
-
-```markdown
-## Dispatch-Tabelle
-| Modus | Modul | Laden |
-|-------|-------|-------|
-| 1: Specify | references/01-specify.md | Bei Modus-Aktivierung |
-```
-
-### 8. Standardisierte Modul-Sektionen
-
-Jedes Modul sollte enthalten: Profil-Steuerung, Ablauf, Output-Template, Stringenz-Regeln, Erweiterbarkeit, Fehlerbehandlung, GP-Mapping, Erzeugte Artefakte.
-
-### 9. Skill testen
-
-Teste jeden Modus mit:
-- Minimalem Input (erkennt der Skill den Modus?)
-- Komplexem Input (erzeugt er alle Artefakte?)
-- Edge Cases (was passiert bei fehlendem Kontext?)
-- Sprachtest (Deutsch → Deutsch, Englisch → Englisch?)
+- **Enforcement wirkt nur in der Session.** Phase Gates, F-Stufen und Anti-Pattern-Erkennung greifen, solange Claude den Skill geladen hat. Es gibt keinen Linter, der eine fertige `spec.md` außerhalb der Session prüft, und keinen Exit-Code für eine Pipeline.
+- **Zwei Schweregrad-Dialekte nebeneinander.** `enforcement-engine.md` und Modus 10 arbeiten mit F-Stufen, mehrere ältere Module noch mit BLOCKER/MAJOR/MINOR. Das Mapping am Ende von `references/checklists/kritis-nfr.md` deckt drei der sechs Stufen ab. Solange das so ist, hängt die gemeldete Stufe davon ab, welches Modul antwortet.
+- **Keine Rechtsberatung.** Die KRITIS-, DORA- und BAIT-Checklisten sind Arbeitshilfen mit Verweis auf die Rechtsquelle. Sie ersetzen keine aufsichtsrechtliche Prüfung. `@bait` ist ausdrücklich ein Stub.
+- **Kein Release-Artefakt.** Kein Tag, kein Paket, kein Download. Installation heißt: Verzeichnis kopieren.
+- **Deutsch als Arbeitssprache.** Der Skill antwortet englisch auf englische Eingaben, die Referenzdateien und Checklisten bleiben deutsch.
 
 ---
 
-## Quellen & Einflüsse
+## Roadmap
 
-| Quelle | Beitrag zu SpecForge |
-|--------|---------------------|
-| [GitHub Spec Kit](https://github.com/github/spec-kit) | Spec-Driven Development Workflow, Slash-Commands, Phasenmodell |
-| Harness-Patterns | Golden Principles, Spec-First Chain, Folder Convention, Reviewer-Agenten, Hook-Architektur |
-| [EARS](https://ieeexplore.ieee.org/document/5328509) | Easy Approach to Requirements Syntax — 5 Requirement-Patterns |
-| [Gherkin](https://cucumber.io/docs/gherkin/) | Acceptance Criteria als Given/When/Then |
-| [STRIDE](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats) | Threat Modeling Framework — 6 Bedrohungskategorien |
-| KRITIS / NIS2 / DSGVO | Regulatorischer Rahmen für kritische Infrastrukturen |
-| Cynefin Framework (Dave Snowden, 1999) | Phase 0 — Komplexitätseinschätzung vor Modus-Wahl |
-| Impact Mapping (Gojko Adzic, 2012) | Phase 0 — Zielorientierte Scope-Validierung |
-| Socratic Method (Platon/Sokrates) | Clarify-Modus — Sokratische Spezifikationsklärung |
-| Five Whys (Taiichi Ohno, Toyota) | BLOCKER-Analyse in Clarify |
-| MECE Principle (Barbara Minto, McKinsey) | Analyze-Modus — Konsistenzprüfung über 5 Dimensionen |
-| Devil's Advocate + Steelmanning | Stakeholder-Simulation — systematische Gegenargumentation |
-| Morphological Box (Fritz Zwicky, 1940er) | Plan-Modus — Systematische Lösungsraum-Exploration |
-| Pugh Matrix (Stuart Pugh, 1991) | Plan-Modus — Strukturierte Technologiebewertung |
-| DDD taktisches Design (Eric Evans, 2003) | Datenmodell in spec.md |
-| BLUF + Pyramid Principle (US-Militär / Barbara Minto) | Spec-Zusammenfassungen |
-| MoSCoW (Dai Clegg, DSDM) | Story-Priorisierung |
-| ADR nach Nygard (Michael Nygard, 2011) | Architecture Decision Records |
+Offen, in dieser Reihenfolge:
+
+1. **Schweregrade vereinheitlichen** — BLOCKER/MAJOR/MINOR in den Modulen auf F-Stufen umstellen, damit derselbe Mangel in jedem Modus dieselbe Stufe bekommt.
+2. **Beispiel-Spezifikationen ins Repo** — hier liegen nur Templates und Eingabe-Prompts, keine fertige Spec, an der sich ein Ergebnis messen ließe.
+3. **`@bait` vervollständigen** — vom Stub auf die Kapitel der BaFin-Rundschreiben 10/2017 (BA) und 10/2021 (BA).
+4. **Weitere Regulierungen** — MaRisk, PCI-DSS 4.0, EnWG/IT-Sicherheitskatalog. Priorisierung in [CONTRIBUTING-CHECKLISTS.md](CONTRIBUTING-CHECKLISTS.md), Abschnitt 5.
+5. **Release mit Tag** — damit eine Version zitierbar wird und die Landingpage auf etwas Festes zeigen kann.
+6. **Englische Fassung** des Payloads.
+
+---
+
+## Weiterführende Dokumente
+
+| Dokument | Inhalt |
+|----------|--------|
+| [docs/skill-als-blaupause.md](docs/skill-als-blaupause.md) | SpecForge als Muster für eigene Claude-Skills: Frontmatter, Modi, Output-Templates, Qualitätsregeln |
+| [docs/quellen-und-einfluesse.md](docs/quellen-und-einfluesse.md) | Herkunft der Methoden: Spec Kit, EARS, Gherkin, STRIDE, Cynefin und die übrigen |
+| [CONTRIBUTING-CHECKLISTS.md](CONTRIBUTING-CHECKLISTS.md) | Schema, Validierung und Kandidatenliste für eigene Regulierungs-Checklisten |
 
 ---
 
 ## Versionierung
+
+SpecForge führt zwei Versionen, und nur diese zwei:
+
+| Gegenstand | Schema | Ort |
+|------------|--------|-----|
+| Skill-Version | `MAJOR.MINOR`, aktuell 3.2 | Tabelle unten, Badge auf der Landingpage |
+| Artefakt-Version | `YYYY.MM.DD.N`, N = laufende Nummer am selben Tag | `version:`-Feld im Header jeder erzeugten `spec.md`, `constitution.md` und `plan.md` |
+
+Verbindlich ist die Artefakt-Versionierung in [SKILL.md](SKILL.md), Abschnitt Versionierung. Die Templates unter `references/templates/` geben dasselbe Schema vor. Die früher genannte Schreibweise `v<YYMM>-green` war ein Audit-Status, keine Version, und wird nicht mehr verwendet.
 
 | Version | Datum | Änderung |
 |---------|-------|---------|

--- a/README.md
+++ b/README.md
@@ -384,21 +384,12 @@ SpecForge führt zwei Versionen, und nur diese zwei:
 
 | Gegenstand | Schema | Ort |
 |------------|--------|-----|
-| Skill-Version | `MAJOR.MINOR`, aktuell 3.2 | Tabelle unten, Badge auf der Landingpage |
+| Skill-Version | `MAJOR.MINOR`, aktuell 3.2 | [CHANGELOG.md](CHANGELOG.md), Badge auf der Landingpage |
 | Artefakt-Version | `YYYY.MM.DD.N`, N = laufende Nummer am selben Tag | `version:`-Feld im Header jeder erzeugten `spec.md`, `constitution.md` und `plan.md` |
 
 Verbindlich ist die Artefakt-Versionierung in [SKILL.md](SKILL.md), Abschnitt Versionierung. Die Templates unter `references/templates/` geben dasselbe Schema vor. Die früher genannte Schreibweise `v<YYMM>-green` war ein Audit-Status, keine Version, und wird nicht mehr verwendet.
 
-| Version | Datum | Änderung |
-|---------|-------|---------|
-| 1.0 | 2025-10 | Initial: Specify, Plan, Tasks, Review, Stakeholder-Sim, Management |
-| 2.0 | 2026-03 | +Clarify, +Analyze, +Checklist, +Research, +Quickstart. SpecKit v3 Alignment. RE Butler entfernt. Single-File-Architektur. |
-| 2.1 | 2026-03 | +Phase 0 (Cynefin + Impact Mapping), 15 methodische Frameworks mit Aktivieren-Eingrenzen-Prüfen-Muster, Sokratische Klärung, MECE-Analyse, Devil's Advocate + Steelmanning, Morphological Box + Pugh Matrix, DDD-Datenmodell, BLUF-Zusammenfassungen. |
-| 2.2 | 2026-03 | +Modus 9 Discover (Bestandsdokumentation & Reverse Spec). Zwei verpflichtende QS-Schleifen: Vollständigkeit + Konsistenz/Stringenz. Rückwärts-Validierung. discovery-protocol.md und migration-delta.md als neue Artefakte. |
-| 2.3 | 2026-03 | +Anhang I Enforcement Engine: State Machine (INIT→COMPLETE), Phase Gates G0–G8, Skip-Protokoll, Vage-Begriffe-Scanner, Anti-Pattern-Erkennung. +5W-Pflichtblock für Reverse-Engineering. +Artefakt-Vollständigkeits-Check. +Session-Status-Anzeige. 21 Interaktions- + 26 Qualitätsregeln. |
-| 3.0 (v202-green) | 2026-03 | **Architektur-Wechsel: Single-File → Multi-File.** Orchestrator (SKILL.md, 395 Zeilen) + 9 Fachmodule + 9 Support-Dateien = 19 Dateien, 3.143 Zeilen. Jedes Modul erhält standardisierte Sektionen: Stringenz-Regeln, Erweiterbarkeit, Fehlerbehandlung, GP-Mapping. Orchestrator mit Pre-Flight Checks, Profil-Resolution Cascade, Calendar Versioning, Audit Trail, Session-Retrospektive, 8 Built-in Extension Points. Deterministische Rollenauswahl (M06), GP-Score-Formel (M07), 7 Management-Funktionen (M08), QS-Loops mit Terminierung (M09). Autoresearch-optimiert: 600 Assertions, 6 Dimensionen, 68%→80% Score über 5 Iterationen. |
-| 3.1 | 2026-03 | **DORA-Integration & F-Stufen-System.** +F-Stufen (F0–F5) nach PrüfbV §27 ersetzen binäres Pass/Fail. +CONDITIONAL als dritter Gate-Ausgang (Risiko-Akzeptanz). +Perspektive als orthogonale Dimension zu Profil (Lieferkettenrolle). +Manifest-Auto-Detection für Extensions. +DORA-Extension (58 Prüfpunkte, 6 Kategorien, 3 Perspektiven). +BAIT-Stub (8 Prüfpunkte). +CONTRIBUTING-CHECKLISTS.md mit Schema, Validierung und Kandidatenliste. +Erweiterter Audit Trail mit F-Stufen und Perspektive. |
-| 3.2 | 2026-03 | **Qualitätserweiterungen aus RE-Skill-Analyse.** +AP-08 SOPHIST-Verletzung (Passiv, Negation, Generik, unvollständige Aufzählung, implizite Zeitangabe) mit SOPHIST-Blocklist. +`[Offen: ...]`-Marker für unvollständige Stories (F3 nach Clarify). +Story-Quality-Score (SQS) als numerische Qualitätsbewertung (0–5) in Review und Analyze. +Modus 10 Derive: Testfall-Ableitung aus Gherkin-Szenarien mit Testabdeckungsmatrix, 6 Testfall-Typen, Traceability. +MCP-Kontext-Pre-Flight in Specify für externe Quellen (Figma, GitHub, Confluence, Jira). |
+Die Versionsgeschichte von 1.0 bis 3.2 steht in [CHANGELOG.md](CHANGELOG.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SpecForge — Specs schmieden, nicht schreiben
 
+[![CI](https://github.com/GodModeAI2025/specforge-ai-skill/actions/workflows/ci.yml/badge.svg)](https://github.com/GodModeAI2025/specforge-ai-skill/actions/workflows/ci.yml)
+
 **Spec-Driven Requirements Engineering als KI-Skill für Claude.**
 
 SpecForge kombiniert [GitHub Spec Kit](https://github.com/github/spec-kit), Harness-Patterns (Golden Principles, Spec-First Chain, STRIDE, Folder Convention) mit EARS-Syntax, Gherkin Acceptance Criteria und automatischen KRITIS/NIS2-NFRs zu einem modularen, selbsttragenden Skill-System.
@@ -300,7 +302,7 @@ specforge/
         └── @bait/                    manifest.md + 8 Prüfpunkte, Stub
 ```
 
-**Skill-Payload: 24 Dateien.** Orchestrator + 10 Fachmodule + 13 Support-Dateien.
+**Skill-Payload: 24 Dateien.** Orchestrator + 10 Fachmodule + 13 Support-Dateien. Die Angaben prüft die CI gegen den Verzeichnisbaum, siehe `scripts/check-docs-numbers.py`.
 
 ### Warum Multi-File?
 
@@ -344,6 +346,7 @@ Jedes der 10 Fachmodule (M01–M10) folgt einer einheitlichen Struktur:
 
 SpecForge ist Prompt-Text, kein Programm. Daraus folgen Grenzen, die keine Version wegräumt:
 
+- **Die CI prüft den Skill, nicht die Ergebnisse.** Der Workflow in `.github/workflows/ci.yml` hält Referenzpfade, Frontmatter, Checklisten und Zahlenangaben konsistent. Ob eine damit erzeugte Spezifikation fachlich taugt, beurteilt weiterhin ein Mensch.
 - **Enforcement wirkt nur in der Session.** Phase Gates, F-Stufen und Anti-Pattern-Erkennung greifen, solange Claude den Skill geladen hat. Es gibt keinen Linter, der eine fertige `spec.md` außerhalb der Session prüft, und keinen Exit-Code für eine Pipeline.
 - **Zwei Schweregrad-Dialekte nebeneinander.** `enforcement-engine.md` und Modus 10 arbeiten mit F-Stufen, mehrere ältere Module noch mit BLOCKER/MAJOR/MINOR. Das Mapping am Ende von `references/checklists/kritis-nfr.md` deckt drei der sechs Stufen ab. Solange das so ist, hängt die gemeldete Stufe davon ab, welches Modul antwortet.
 - **Keine Rechtsberatung.** Die KRITIS-, DORA- und BAIT-Checklisten sind Arbeitshilfen mit Verweis auf die Rechtsquelle. Sie ersetzen keine aufsichtsrechtliche Prüfung. `@bait` ist ausdrücklich ein Stub.

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Die 10 Fachmodule folgen weitgehend derselben Struktur. Wo eine Sektion fehlt od
 | Erweiterbarkeit | Custom-Extension-Punkte mit Pfaden. Fehlt in `04-analyze.md` und `05-checklist.md` |
 | Fehlerbehandlung | Tabellarische Edge-Case-Behandlung, vier bis neun Fälle je nach Modul |
 | GP-Mapping | Zuordnung relevanter Golden Principles. Fehlt in `01-specify.md`, `02-clarify.md` und `07-review.md` |
-| Erzeugte Artefakte | Artefakt-Tabelle mit Pfaden |
+| Erzeugte Artefakte | Artefakt-Tabelle mit Pfaden. In `02-clarify.md` heißt die Sektion „Erzeugte/aktualisierte Artefakte“ |
 
 ### Orchestrator-Features (SKILL.md)
 

--- a/README.md
+++ b/README.md
@@ -312,19 +312,19 @@ specforge/
 - **Audit-freundlich** — jede Datei unabhängig bewertbar und testbar
 - **Context-Window-effizient** — Claude lädt Orchestrator plus benötigtes Modul, nicht den ganzen Payload
 
-### Was jedes Modul enthält (Standard-Sektionen)
+### Was die Fachmodule enthalten (Standard-Sektionen)
 
-Jedes der 10 Fachmodule (M01–M10) folgt einer einheitlichen Struktur:
+Die 10 Fachmodule folgen weitgehend derselben Struktur. In allen zehn stehen Fehlerbehandlung und Erzeugte Artefakte, bei den übrigen Sektionen nennt die Tabelle die Ausnahmen:
 
 | Sektion | Beschreibung |
 |---------|-------------|
-| Profil-Steuerung | KRITIS/Standard/Startup-spezifisches Verhalten |
+| Profil-Steuerung | KRITIS/Standard/Startup-spezifisches Verhalten. Eigene Sektion in acht Modulen; `01-specify.md` behandelt die Profilwahl als Ablaufschritt, `02-clarify.md` unter „Wann Pflicht vs. Optional (profilabhängig)“ |
 | Ablauf (deterministisch) | Nummerierte Phasen mit konkreten Schritten |
 | Output-Template | Markdown-Template für erzeugte Artefakte |
-| Stringenz-Regeln (Enforcement) | Tabellarische Regeln mit Schweregraden |
-| Erweiterbarkeit | Custom-Extension-Punkte mit Pfaden |
-| Fehlerbehandlung | Tabellarische Edge-Case-Behandlung (≥5 Fälle) |
-| GP-Mapping | Zuordnung relevanter Golden Principles |
+| Stringenz-Regeln (Enforcement) | Tabellarische Regeln mit Schweregraden. Fehlt in `04-analyze.md` und `05-checklist.md` |
+| Erweiterbarkeit | Custom-Extension-Punkte mit Pfaden. Fehlt in `04-analyze.md` und `05-checklist.md` |
+| Fehlerbehandlung | Tabellarische Edge-Case-Behandlung, vier bis neun Fälle je nach Modul |
+| GP-Mapping | Zuordnung relevanter Golden Principles. Fehlt in `01-specify.md`, `02-clarify.md` und `07-review.md` |
 | Erzeugte Artefakte | Artefakt-Tabelle mit Pfaden |
 
 ### Orchestrator-Features (SKILL.md)

--- a/SKILL.md
+++ b/SKILL.md
@@ -210,9 +210,9 @@ SpecForge ist an folgenden Stellen erweiterbar — ohne Änderung an Core-Dateie
 |-----|--------------|----------------|
 | **EARS-Patterns** | Neue Patterns in `references/custom/ears-patterns-custom.md` definieren; Dispatcher prüft Core + Custom | ears-syntax.md (Core), Custom-Datei (Ergänzung) |
 | **Profile** | Neues Profil in specforge.json als `profile_custom`-Objekt mit `base` (KRITIS/Standard/Startup) + `overrides` | specforge.json |
-| **Anti-Patterns** | AP-08+ in `references/custom/anti-patterns-custom.md`; Format identisch zu AP-01–AP-08 | enforcement-engine.md (Core), Custom-Datei (Ergänzung) |
+| **Anti-Patterns** | AP-09+ in `references/custom/anti-patterns-custom.md`; Format identisch zu AP-01–AP-08 | enforcement-engine.md (Core), Custom-Datei (Ergänzung) |
 | **Golden Principles** | GP-11+ in `references/custom/golden-principles-custom.md`; `active_gps` in specforge.json erweitern | golden-principles.md (Core), Custom-Datei (Ergänzung) |
-| **Modi** | Neue Modi als `references/custom/mode-NN-name.md`; Dispatch-Tabelle in specforge.json um Einträge erweiterbar | SKILL.md Dispatch-Tabelle (Core 1–9), Custom (10+) |
+| **Modi** | Neue Modi als `references/custom/mode-NN-name.md`; Dispatch-Tabelle in specforge.json um Einträge erweiterbar | SKILL.md Dispatch-Tabelle (Core 1–10), Custom (11+) |
 | **Review-Rollen** | Neue Rollen in `references/custom/@team-review-rollen/` | 06-stakeholder-sim.md |
 | **NFR-Kategorien** | Neue Kategorien in `references/custom/nfr-custom.md` | kritis-nfr.md (Core), Custom-Datei (Ergänzung) |
 | **Checklisten** | `references/custom/*.md` oder `@scope/`-Pakete | 05-checklist.md |

--- a/docs/quellen-und-einfluesse.md
+++ b/docs/quellen-und-einfluesse.md
@@ -1,0 +1,28 @@
+# Quellen und Einflüsse
+
+Ausgelagert aus dem README. Woher die Methoden stammen, die SpecForge anwendet.
+
+Zurück zum [README](../README.md).
+
+---
+
+| Quelle | Beitrag zu SpecForge |
+|--------|---------------------|
+| [GitHub Spec Kit](https://github.com/github/spec-kit) | Spec-Driven Development Workflow, Slash-Commands, Phasenmodell |
+| Harness-Patterns | Golden Principles, Spec-First Chain, Folder Convention, Reviewer-Agenten, Hook-Architektur |
+| [EARS](https://ieeexplore.ieee.org/document/5328509) | Easy Approach to Requirements Syntax — 5 Requirement-Patterns |
+| [Gherkin](https://cucumber.io/docs/gherkin/) | Acceptance Criteria als Given/When/Then |
+| [STRIDE](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats) | Threat Modeling Framework — 6 Bedrohungskategorien |
+| KRITIS / NIS2 / DSGVO | Regulatorischer Rahmen für kritische Infrastrukturen |
+| Cynefin Framework (Dave Snowden, 1999) | Phase 0 — Komplexitätseinschätzung vor Modus-Wahl |
+| Impact Mapping (Gojko Adzic, 2012) | Phase 0 — Zielorientierte Scope-Validierung |
+| Socratic Method (Platon/Sokrates) | Clarify-Modus — Sokratische Spezifikationsklärung |
+| Five Whys (Taiichi Ohno, Toyota) | BLOCKER-Analyse in Clarify |
+| MECE Principle (Barbara Minto, McKinsey) | Analyze-Modus — Konsistenzprüfung über 5 Dimensionen |
+| Devil's Advocate + Steelmanning | Stakeholder-Simulation — systematische Gegenargumentation |
+| Morphological Box (Fritz Zwicky, 1940er) | Plan-Modus — Systematische Lösungsraum-Exploration |
+| Pugh Matrix (Stuart Pugh, 1991) | Plan-Modus — Strukturierte Technologiebewertung |
+| DDD taktisches Design (Eric Evans, 2003) | Datenmodell in spec.md |
+| BLUF + Pyramid Principle (US-Militär / Barbara Minto) | Spec-Zusammenfassungen |
+| MoSCoW (Dai Clegg, DSDM) | Story-Priorisierung |
+| ADR nach Nygard (Michael Nygard, 2011) | Architecture Decision Records |

--- a/docs/skill-als-blaupause.md
+++ b/docs/skill-als-blaupause.md
@@ -1,0 +1,112 @@
+# SpecForge als Blaupause für eigene Skills
+
+Ausgelagert aus dem README. Die Methodik hinter SpecForge, falls du einen
+eigenen Claude-Skill nach demselben Muster bauen willst.
+
+Zurück zum [README](../README.md).
+
+---
+
+SpecForge kann als Blaupause für eigene Skills dienen. Hier die Methodik:
+
+## 1. Frontmatter definieren
+```yaml
+---
+name: MeinSkill
+description: Kurzbeschreibung mit Trigger-Keywords. Verwende diesen Skill
+  IMMER bei: keyword1, keyword2, keyword3. Auch bei "natürlichsprachlicher
+  Trigger", "weiterer Trigger".
+---
+```
+
+**Regeln für gute Trigger:**
+- Technische Begriffe UND natürlichsprachliche Formulierungen
+- "Verwende diesen Skill IMMER bei:" signalisiert Claude den Aktivierungszeitpunkt
+- "Auch bei:" für indirekte Trigger ("prüfe meine X", "was fehlt bei Y")
+
+## 2. Session-Isolation festlegen
+
+Entscheide: Darf der Skill auf Memories/Vorwissen zugreifen oder ist jede Session ein Blank Slate?
+
+```markdown
+## Wissensquellen
+MeinSkill arbeitet ausschließlich mit:
+1. Session-Kontext
+2. Eigenrecherche via Web Search
+3. Skill-eigene Referenzen
+```
+
+## 3. Modi definieren
+
+Jeder Modus hat:
+- **Trigger:** Woran erkennt der Skill, dass dieser Modus gemeint ist?
+- **Phasen:** Welche Schritte werden durchlaufen?
+- **Artefakte:** Was wird erzeugt?
+- **Abschlusskriterium:** Wann ist der Modus fertig?
+
+```markdown
+### Modus N: [Name]
+**Trigger:** [Beschreibung]
+**Phase Na: [Schritt]**
+1. ...
+2. ...
+**Erzeugte Artefakte:**
+- ...
+```
+
+## 4. Output-Formate als Templates definieren
+
+Gib Claude exakte Templates mit Platzhaltern:
+
+```markdown
+## Output-Format: [Artefakt-Typ]
+\```markdown
+### [ID] [Titel]
+**Typ**: ...
+**Priorität**: ...
+#### Abschnitt
+[Inhalt]
+\```
+```
+
+## 5. Qualitätsregeln als enforceable Constraints
+
+Nicht "versuche X" sondern "X ist Pflicht":
+
+```markdown
+## Qualitätsregeln (immer aktiv)
+1. **Regel** — Enforcement-Beschreibung
+2. **Regel** — Enforcement-Beschreibung
+```
+
+## 6. Interaktionsregeln für Gesprächsführung
+
+```markdown
+## Interaktionsregeln
+1. Max. N Fragen pro Runde
+2. Nach [Aktion] einmal validieren
+3. Smarte Annahmen mit `[Annahme: ...]` kennzeichnen
+```
+
+## 7. Referenzen als separate Dateien
+
+Statt alles inline: Module in `references/` auslagern und per Dispatch-Tabelle referenzieren:
+
+```markdown
+## Dispatch-Tabelle
+| Modus | Modul | Laden |
+|-------|-------|-------|
+| 1: Specify | references/01-specify.md | Bei Modus-Aktivierung |
+```
+
+## 8. Standardisierte Modul-Sektionen
+
+Jedes Modul sollte enthalten: Profil-Steuerung, Ablauf, Output-Template, Stringenz-Regeln, Erweiterbarkeit, Fehlerbehandlung, GP-Mapping, Erzeugte Artefakte.
+
+## 9. Skill testen
+
+Teste jeden Modus mit:
+- Minimalem Input (erkennt der Skill den Modus?)
+- Komplexem Input (erzeugt er alle Artefakte?)
+- Edge Cases (was passiert bei fehlendem Kontext?)
+- Sprachtest (Deutsch → Deutsch, Englisch → Englisch?)

--- a/index.html
+++ b/index.html
@@ -666,8 +666,8 @@ Gherkin-Szenarien ─── Testfall-Ableitung ─── Testabdeckungsmatrix �
           <h3>Claude Code — Projekt-Kontext</h3>
           <ol>
             <li>Skill-Ordner in <code>.claude/knowledge/</code> legen</li>
-            <li>Optional: In <code>CLAUDE.md</code> referenzieren</li>
-            <li>Automatisch geladen</li>
+            <li>In <code>CLAUDE.md</code> referenzieren</li>
+            <li>Claude lädt <code>SKILL.md</code> über diese Referenz</li>
           </ol>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       "Clarify — Sokratische Spezifikationsklärung",
       "Plan & Tasks — Von Spec zu Backlog mit ADRs und Explore-Phase",
       "Analyze — MECE-Konsistenzprüfung über 5 Dimensionen mit Re-Analyze-Loop",
-      "Checklist — 4 Checklist-Typen (Spec-Readiness, Compliance, Security, Domain)",
+      "Checklist — 4 Checklist-Typen (Spec-Readiness, Plan-Readiness, Custom, Domain)",
       "Stakeholder-Simulation — Deterministische Rollenauswahl, Gate-Integration",
       "Review — 3-Ebenen-Review mit GP-Score-Formel",
       "Management — 7 Funktionen inkl. Traceability, SFC-Audit, Freshness-Check",
@@ -377,7 +377,7 @@
         <div class="feature">
           <span class="icon">5</span>
           <h3>Checklist</h3>
-          <p>4 Checklist-Typen: Spec-Readiness, Compliance, Security, Domain-spezifisch. Wiederverwendbare Quality Gates.</p>
+          <p>4 Checklist-Typen: Spec-Readiness, Plan-Readiness, Custom, Domain. Wiederverwendbare Quality Gates.</p>
         </div>
         <div class="feature">
           <span class="icon">6</span>

--- a/index.html
+++ b/index.html
@@ -475,7 +475,7 @@
   <span class="highlight">05-checklist.md</span>         <span class="highlight">10-derive.md</span>
   checklists/  templates/  conventions/  enforcement/  custom/</div>
       <p style="text-align:center; color:var(--text-muted); font-size:0.9rem; margin-top:24px;">
-        Jedes Modul folgt einer einheitlichen Struktur:
+        Wiederkehrende Sektionen der Fachmodule. Fehlerbehandlung und Erzeugte Artefakte stehen in allen zehn Modulen, die übrigen in sieben oder acht davon:
       </p>
       <div class="module-sections">
         <div class="module-section"><span class="dot" style="background:var(--accent);"></span> Profil-Steuerung</div>
@@ -728,7 +728,7 @@ Gherkin-Szenarien ─── Testfall-Ableitung ─── Testabdeckungsmatrix �
   <noscript>
     <section>
       <h2>SpecForge — Zusammenfassung</h2>
-      <p>SpecForge ist ein Open-Source Claude-Skill (v3.2) für Spec-Driven Requirements Engineering mit Governance-Enforcement. Multi-File-Architektur: Orchestrator (SKILL.md) + 10 Fachmodule + 13 Support-Dateien = 24 Dateien. 10 Modi: Specify, Clarify, Plan, Analyze, Checklist, Stakeholder-Simulation, Review, Management, Discover, Derive. 15 etablierte Methoden (Cynefin, Socratic Method, MECE, STRIDE, EARS, Gherkin, DDD, MoSCoW, ADR nach Nygard, Five Whys, Devil's Advocate, Morphological Box, Pugh Matrix, BLUF/Pyramid Principle, Impact Mapping). 10 Golden Principles. F-Stufen-Schweregrade (F0–F5) nach PrüfbV §27. Story-Quality-Score (SQS 0–5). DORA/BAIT-Extensions. 8 Anti-Patterns (inkl. SOPHIST-Verletzung). Testfall-Ableitung (Modus 10 Derive) mit 6 Testfall-Typen und Testabdeckungsmatrix. Enforcement Engine mit State Machine, Phase Gates G0-G5 und G0-RE bis G4-RE, Skip-Protokoll und Anti-Pattern-Erkennung. Jedes Modul mit standardisierten Sektionen: Profil-Steuerung, Stringenz-Regeln, Erweiterbarkeit, Fehlerbehandlung, GP-Mapping. 3 Profile: KRITIS, Standard, Startup. MIT-Lizenz. GitHub: github.com/GodModeAI2025/specforge-ai-skill</p>
+      <p>SpecForge ist ein Open-Source Claude-Skill (v3.2) für Spec-Driven Requirements Engineering mit Governance-Enforcement. Multi-File-Architektur: Orchestrator (SKILL.md) + 10 Fachmodule + 13 Support-Dateien = 24 Dateien. 10 Modi: Specify, Clarify, Plan, Analyze, Checklist, Stakeholder-Simulation, Review, Management, Discover, Derive. 15 etablierte Methoden (Cynefin, Socratic Method, MECE, STRIDE, EARS, Gherkin, DDD, MoSCoW, ADR nach Nygard, Five Whys, Devil's Advocate, Morphological Box, Pugh Matrix, BLUF/Pyramid Principle, Impact Mapping). 10 Golden Principles. F-Stufen-Schweregrade (F0–F5) nach PrüfbV §27. Story-Quality-Score (SQS 0–5). DORA/BAIT-Extensions. 8 Anti-Patterns (inkl. SOPHIST-Verletzung). Testfall-Ableitung (Modus 10 Derive) mit 6 Testfall-Typen und Testabdeckungsmatrix. Enforcement Engine mit State Machine, Phase Gates G0-G5 und G0-RE bis G4-RE, Skip-Protokoll und Anti-Pattern-Erkennung. Wiederkehrende Modul-Sektionen: Fehlerbehandlung und Erzeugte Artefakte in allen zehn Modulen, Profil-Steuerung, Stringenz-Regeln, Erweiterbarkeit und GP-Mapping in sieben oder acht davon. 3 Profile: KRITIS, Standard, Startup. MIT-Lizenz. GitHub: github.com/GodModeAI2025/specforge-ai-skill</p>
     </section>
   </noscript>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SpecForge — Specs schmieden, nicht schreiben</title>
-  <meta name="description" content="Spec-Driven Requirements Engineering als KI-Skill für Claude. 10 Modi, 15 Methoden, 28 Dateien, ~4.900 Zeilen. F-Stufen (F0–F5), Story-Quality-Score, DORA/BAIT-Extensions, Testfall-Ableitung. Von der Idee zum implementierungsreifen Backlog — oder vom Bestandssystem zurück zur Spec. Open Source.">
+  <meta name="description" content="Spec-Driven Requirements Engineering als KI-Skill für Claude. 10 Modi, 15 Methoden, 24 Dateien. F-Stufen (F0–F5), Story-Quality-Score, DORA/BAIT-Extensions, Testfall-Ableitung. Von der Idee zum implementierungsreifen Backlog — oder vom Bestandssystem zurück zur Spec. Open Source.">
   <meta name="keywords" content="SpecForge, Requirements Engineering, Claude Skill, EARS, Gherkin, STRIDE, KRITIS, NIS2, Spec-Driven Development, AI Skill, Reverse Spec, Bestandsdokumentation, Golden Principles, MECE, Cynefin, MoSCoW, ADR, DDD, Multi-File Skill, Enforcement Engine">
   <meta name="author" content="GodModeAI2025">
   <meta name="robots" content="index, follow">
@@ -12,14 +12,14 @@
   <!-- Open Graph (Facebook, LinkedIn, Perplexity, Slack) -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="SpecForge — Spec-Driven Requirements Engineering als KI-Skill">
-  <meta property="og:description" content="10 Modi, 15 Methoden, 28 Dateien. F-Stufen (F0–F5), DORA/BAIT-Extensions, Story-Quality-Score, Testfall-Ableitung. EARS, Gherkin, STRIDE, KRITIS/NIS2. Enforcement Engine mit Phase Gates. Open Source Claude Skill.">
+  <meta property="og:description" content="10 Modi, 15 Methoden, 24 Dateien. F-Stufen (F0–F5), DORA/BAIT-Extensions, Story-Quality-Score, Testfall-Ableitung. EARS, Gherkin, STRIDE, KRITIS/NIS2. Enforcement Engine mit Phase Gates. Open Source Claude Skill.">
   <meta property="og:url" content="https://godmodeai2025.github.io/specforge-ai-skill/">
   <meta property="og:site_name" content="SpecForge">
   <meta property="og:locale" content="de_DE">
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="SpecForge — Specs schmieden, nicht schreiben">
-  <meta name="twitter:description" content="Spec-Driven Requirements Engineering als KI-Skill für Claude. 10 Modi, 28 Dateien. F-Stufen, DORA-Extensions, Story-Quality-Score, Testfall-Ableitung. Open Source.">
+  <meta name="twitter:description" content="Spec-Driven Requirements Engineering als KI-Skill für Claude. 10 Modi, 24 Dateien. F-Stufen, DORA-Extensions, Story-Quality-Score, Testfall-Ableitung. Open Source.">
   <!-- JSON-LD Structured Data (Google, Perplexity, AI Crawlers) -->
   <script type="application/ld+json">
   {
@@ -28,7 +28,7 @@
     "name": "SpecForge",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Any",
-    "description": "Spec-Driven Requirements Engineering als KI-Skill für Claude. Multi-File-Architektur: Orchestrator (SKILL.md, 494 Zeilen) + 10 Fachmodule + 17 Support-Dateien = 28 Dateien, ~4.900 Zeilen. 10 Modi, 15 etablierte Methoden, F-Stufen (F0–F5), Story-Quality-Score, DORA/BAIT-Extensions, 8 Anti-Patterns, Testfall-Ableitung. Enforcement Engine mit State Machine und Phase Gates. Unterstützt auch Reverse Spec für Bestandsdokumentation.",
+    "description": "Spec-Driven Requirements Engineering als KI-Skill für Claude. Multi-File-Architektur: Orchestrator (SKILL.md) + 10 Fachmodule + 13 Support-Dateien = 24 Dateien. 10 Modi, 15 etablierte Methoden, F-Stufen (F0–F5), Story-Quality-Score, DORA/BAIT-Extensions, 8 Anti-Patterns, Testfall-Ableitung. Enforcement Engine mit State Machine und Phase Gates. Unterstützt auch Reverse Spec für Bestandsdokumentation.",
     "url": "https://godmodeai2025.github.io/specforge-ai-skill/",
     "downloadUrl": "https://github.com/GodModeAI2025/specforge-ai-skill",
     "softwareVersion": "3.2",
@@ -46,8 +46,8 @@
       "Management — 7 Funktionen inkl. Traceability, SFC-Audit, Freshness-Check",
       "Discover — Bestandsdokumentation mit QS-Loops und 5W-Analyse",
       "Derive — Testfall-Ableitung aus Gherkin mit 6 Testfall-Typen und Testabdeckungsmatrix",
-      "Multi-File-Architektur — Orchestrator + 10 Module + 17 Support-Dateien",
-      "Enforcement Engine — Phase Gates G0-G8, F-Stufen (F0–F5), 8 Anti-Patterns",
+      "Multi-File-Architektur — Orchestrator + 10 Fachmodule + 13 Support-Dateien",
+      "Enforcement Engine — Phase Gates G0-G5 und G0-RE bis G4-RE, F-Stufen (F0–F5), 8 Anti-Patterns",
       "Story-Quality-Score (SQS) — Numerische Formulierungsqualität 0–5",
       "DORA/BAIT-Extensions — Regulatorische Compliance-Erweiterungen",
       "Profil-Resolution Cascade — KRITIS / Standard / Startup"
@@ -331,7 +331,7 @@
       <div class="badges">
         <span class="badge badge-blue">Skill für Claude</span>
         <span class="badge badge-green">v3.2</span>
-        <span class="badge badge-purple">28 Dateien</span>
+        <span class="badge badge-purple">24 Dateien</span>
         <span class="badge badge-orange">10 Modi</span>
       </div>
       <div class="cta-group">
@@ -445,35 +445,35 @@
     <div class="container" style="max-width:780px;">
       <h2 style="font-size:1.5rem;">Multi-File-Architektur</h2>
       <p style="text-align:center; color:var(--text-muted); margin-bottom:24px; font-size:1.05rem;">
-        v3.2 wechselt von Single-File (~120 KB) zu einer modularen Architektur.
-        <strong style="color:var(--text);">Orchestrator + 10 Fachmodule + 17 Support-Dateien.</strong>
+        Seit v3.0 liegt SpecForge modular vor statt in einer einzelnen Datei.
+        <strong style="color:var(--text);">Orchestrator + 10 Fachmodule + 13 Support-Dateien.</strong>
       </p>
       <div class="stats">
         <div class="stat">
-          <div class="number">19</div>
+          <div class="number">24</div>
           <div class="label">Dateien</div>
         </div>
         <div class="stat">
-          <div class="number">~4.900</div>
-          <div class="label">Zeilen</div>
-        </div>
-        <div class="stat">
-          <div class="number">494</div>
-          <div class="label">Orchestrator</div>
-        </div>
-        <div class="stat">
           <div class="number">10</div>
-          <div class="label">Module</div>
+          <div class="label">Fachmodule</div>
+        </div>
+        <div class="stat">
+          <div class="number">13</div>
+          <div class="label">Support-Dateien</div>
+        </div>
+        <div class="stat">
+          <div class="number">41</div>
+          <div class="label">KRITIS-Prüfpunkte</div>
         </div>
       </div>
-      <div class="arch-tree"><span class="highlight">SKILL.md</span> <span class="dim">(494 — Orchestrator)</span>
+      <div class="arch-tree"><span class="highlight">SKILL.md</span> <span class="dim">(Orchestrator)</span>
 <span class="highlight">references/</span>
-  <span class="highlight">01-specify.md</span>      <span class="dim">(187)</span>    <span class="highlight">07-review.md</span>       <span class="dim">(207)</span>
-  <span class="highlight">02-clarify.md</span>       <span class="dim">(159)</span>    <span class="highlight">08-management.md</span>   <span class="dim">(199)</span>
-  <span class="highlight">03-plan.md</span>          <span class="dim">(242)</span>    <span class="highlight">09-discover.md</span>     <span class="dim">(215)</span>
-  <span class="highlight">04-analyze.md</span>       <span class="dim">(144)</span>    <span class="highlight">10-derive.md</span>       <span class="dim">(172)</span>
-  <span class="highlight">05-checklist.md</span>     <span class="dim">(132)</span>    checklists/  templates/
-  <span class="highlight">06-stakeholder-sim.md</span> <span class="dim">(155)</span>  conventions/ enforcement/ custom/</div>
+  <span class="highlight">01-specify.md</span>          <span class="highlight">06-stakeholder-sim.md</span>
+  <span class="highlight">02-clarify.md</span>           <span class="highlight">07-review.md</span>
+  <span class="highlight">03-plan.md</span>              <span class="highlight">08-management.md</span>
+  <span class="highlight">04-analyze.md</span>           <span class="highlight">09-discover.md</span>
+  <span class="highlight">05-checklist.md</span>         <span class="highlight">10-derive.md</span>
+  checklists/  templates/  conventions/  enforcement/  custom/</div>
       <p style="text-align:center; color:var(--text-muted); font-size:0.9rem; margin-top:24px;">
         Jedes Modul folgt einer einheitlichen Struktur:
       </p>
@@ -728,7 +728,7 @@ Gherkin-Szenarien ─── Testfall-Ableitung ─── Testabdeckungsmatrix �
   <noscript>
     <section>
       <h2>SpecForge — Zusammenfassung</h2>
-      <p>SpecForge ist ein Open-Source Claude-Skill (v3.2) für Spec-Driven Requirements Engineering mit Governance-Enforcement. Multi-File-Architektur: Orchestrator (SKILL.md, 494 Zeilen) + 10 Fachmodule + 17 Support-Dateien = 28 Dateien, ~4.900 Zeilen. 10 Modi: Specify, Clarify, Plan, Analyze, Checklist, Stakeholder-Simulation, Review, Management, Discover, Derive. 15 etablierte Methoden (Cynefin, Socratic Method, MECE, STRIDE, EARS, Gherkin, DDD, MoSCoW, ADR nach Nygard, Five Whys, Devil's Advocate, Morphological Box, Pugh Matrix, BLUF/Pyramid Principle, Impact Mapping). 10 Golden Principles. F-Stufen-Schweregrade (F0–F5) nach PrüfbV §27. Story-Quality-Score (SQS 0–5). DORA/BAIT-Extensions. 8 Anti-Patterns (inkl. SOPHIST-Verletzung). Testfall-Ableitung (Modus 10 Derive) mit 6 Testfall-Typen und Testabdeckungsmatrix. Enforcement Engine mit State Machine, Phase Gates G0-G8, Skip-Protokoll und Anti-Pattern-Erkennung. Jedes Modul mit standardisierten Sektionen: Profil-Steuerung, Stringenz-Regeln, Erweiterbarkeit, Fehlerbehandlung, GP-Mapping. 3 Profile: KRITIS, Standard, Startup. MIT-Lizenz. GitHub: github.com/GodModeAI2025/specforge-ai-skill</p>
+      <p>SpecForge ist ein Open-Source Claude-Skill (v3.2) für Spec-Driven Requirements Engineering mit Governance-Enforcement. Multi-File-Architektur: Orchestrator (SKILL.md) + 10 Fachmodule + 13 Support-Dateien = 24 Dateien. 10 Modi: Specify, Clarify, Plan, Analyze, Checklist, Stakeholder-Simulation, Review, Management, Discover, Derive. 15 etablierte Methoden (Cynefin, Socratic Method, MECE, STRIDE, EARS, Gherkin, DDD, MoSCoW, ADR nach Nygard, Five Whys, Devil's Advocate, Morphological Box, Pugh Matrix, BLUF/Pyramid Principle, Impact Mapping). 10 Golden Principles. F-Stufen-Schweregrade (F0–F5) nach PrüfbV §27. Story-Quality-Score (SQS 0–5). DORA/BAIT-Extensions. 8 Anti-Patterns (inkl. SOPHIST-Verletzung). Testfall-Ableitung (Modus 10 Derive) mit 6 Testfall-Typen und Testabdeckungsmatrix. Enforcement Engine mit State Machine, Phase Gates G0-G5 und G0-RE bis G4-RE, Skip-Protokoll und Anti-Pattern-Erkennung. Jedes Modul mit standardisierten Sektionen: Profil-Steuerung, Stringenz-Regeln, Erweiterbarkeit, Fehlerbehandlung, GP-Mapping. 3 Profile: KRITIS, Standard, Startup. MIT-Lizenz. GitHub: github.com/GodModeAI2025/specforge-ai-skill</p>
     </section>
   </noscript>
 

--- a/references/01-specify.md
+++ b/references/01-specify.md
@@ -152,7 +152,7 @@ SpecForge prüft diese Checkliste und gibt ein Pass/Fail-Ergebnis aus:
 | Erweiterungspunkt | Wie | Wo |
 |-------------------|-----|-----|
 | Neue EARS-Patterns | `references/custom/ears-patterns-custom.md` | Custom Extension |
-| Neue Anti-Patterns | AP-08+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
+| Neue Anti-Patterns | AP-09+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
 | Neue NFR-Kategorien | `references/custom/nfr-custom.md` | Custom Extension |
 | Branchenspezifische Checklisten | `references/custom/@branche-compliance/` | Custom Extension |
 | Neue GP-Checks | GP-11+ in `references/custom/golden-principles-custom.md` | Custom Extension |

--- a/references/02-clarify.md
+++ b/references/02-clarify.md
@@ -129,7 +129,7 @@ Clarify ist abgeschlossen wenn:
 |-------------------|-----|-----|
 | Neue Clarify-Techniken | `references/custom/clarify-techniques-custom.md` | Custom Extension |
 | Branchenspezifische Fragen-Templates | `references/custom/@branche-compliance/clarify-templates.md` | Custom Extension |
-| Neue Anti-Patterns | AP-08+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
+| Neue Anti-Patterns | AP-09+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
 | Custom Fragen-Kataloge | `references/custom/clarify-katalog.md` | Custom Extension |
 
 ## Fehlerbehandlung

--- a/references/03-plan.md
+++ b/references/03-plan.md
@@ -199,7 +199,7 @@ Empfehlung: IMMER Analyze nach Tasks ausführen.
 |-------------------|-----|-----|
 | Neue Task-Typen | Relevanz-Matrix in spec-first-chain.md erweitern | Convention |
 | Branchenspezifische Plan-Checklisten | `references/custom/@branche-compliance/plan-checks.md` | Custom Extension |
-| Neue Anti-Patterns | AP-08+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
+| Neue Anti-Patterns | AP-09+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
 | Custom Research-Templates | `references/custom/research-template-custom.md` | Custom Extension |
 | Neue Architektur-Bewertungsmethoden | `references/custom/architecture-methods.md` | Custom Extension |
 

--- a/references/06-stakeholder-sim.md
+++ b/references/06-stakeholder-sim.md
@@ -108,7 +108,7 @@ Folgende Regeln werden **automatisch** bei jeder Simulation durchgesetzt:
 | Vage Begriffe aus Blocklist erkannt | Jedes Finding gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | BLOCKER |
 | Fragen-Budget | Max. 3 Fragen pro Runde an den Nutzer; Stakeholder-Fragen intern unbegrenzt | n.a. (Budget-Überschreitung = Skip) |
 | Anti-Pattern-Prüfung | AP-01–AP-08 + custom APs aus `references/custom/anti-patterns-custom.md` | Schweregrad laut AP-Tabelle |
-| Spec-Artefakt als Datei | Output als stakeholder-sim-protocol.md, nicht inline | MAJOR (AP-09) |
+| Spec-Artefakt als Datei | Output als stakeholder-sim-protocol.md, nicht inline | MAJOR |
 
 ## Erweiterbarkeit
 

--- a/references/06-stakeholder-sim.md
+++ b/references/06-stakeholder-sim.md
@@ -115,7 +115,7 @@ Folgende Regeln werden **automatisch** bei jeder Simulation durchgesetzt:
 | Erweiterungspunkt | Wie | Wo |
 |-------------------|-----|-----|
 | Neue Rollen | `references/custom/@team-review-rollen/rollen/*.md` mit Rolle, Fokus, Methodik, Pflicht-Frage | Custom Extension |
-| Neue Anti-Patterns | `references/custom/anti-patterns-custom.md` (AP-08+) | Custom Extension |
+| Neue Anti-Patterns | `references/custom/anti-patterns-custom.md` (AP-09+) | Custom Extension |
 | Branchenspezifische Prüfaspekte | `references/custom/@branche-compliance/checklisten/*.md` — werden als Zusatz-Prüfpunkte jeder Rolle mitgegeben | Custom Extension |
 | Profil-spezifische Rollen-Defaults | Konfigurierbar über `specforge.json → extensions` | specforge.json |
 

--- a/references/07-review.md
+++ b/references/07-review.md
@@ -176,7 +176,7 @@ Schwellwerte:
 | Neue Ebene-1-Prüfpunkte | RQ-09+ in `references/custom/review-quality-custom.md` | Custom Extension |
 | Neue GP-Checks | GP-11+ in `references/custom/golden-principles-custom.md` | Custom Extension |
 | Branchenspezifische Security-Checks | SC-06+ in `references/custom/@branche-compliance/security-checks.md` | Custom Extension |
-| Neue Anti-Patterns | AP-08+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
+| Neue Anti-Patterns | AP-09+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
 | Custom Review-Rollen (→ Modus 6 Integration) | `references/custom/@team-review-rollen/rollen/*.md` | Custom Extension |
 
 ## Fehlerbehandlung

--- a/references/08-management.md
+++ b/references/08-management.md
@@ -157,7 +157,7 @@ Folgende Regeln werden bei jeder Management-Funktion **automatisch** durchgesetz
 | Neue Traceability-Prüfpunkte | TM-08+ in `references/custom/traceability-custom.md` | Custom Extension |
 | Neue SFC-Schritte | Schritt 9+ in `references/custom/spec-first-chain-custom.md` | Custom Extension |
 | Branchenspezifische Freshness-Regeln | `references/custom/@branche-compliance/freshness-rules.md` | Custom Extension |
-| Neue Anti-Patterns für Spec-Diff | `references/custom/anti-patterns-custom.md` (AP-08+) | Custom Extension |
+| Neue Anti-Patterns für Spec-Diff | `references/custom/anti-patterns-custom.md` (AP-09+) | Custom Extension |
 | Custom Tech-Debt-Kategorien | Erweiterbar über zusätzliche Spalten in tech-debt-tracker.md | Projekt-spezifisch |
 | Neue Management-Funktionen | 8.8+ als `references/custom/management-custom.md` | Custom Extension |
 

--- a/references/09-discover.md
+++ b/references/09-discover.md
@@ -167,7 +167,7 @@ Nach G4-RE: Übergang in Forward-Path ab G2 (Clarify) oder G3 (Plan).
 | Erweiterungspunkt | Wie | Wo |
 |-------------------|-----|-----|
 | Neue QS-Prüfpunkte | QS1-06+ / QS2-07+ in `references/custom/discover-qs-custom.md` | Custom Extension |
-| Neue Anti-Patterns | AP-08+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
+| Neue Anti-Patterns | AP-09+ in `references/custom/anti-patterns-custom.md` | Custom Extension |
 | Branchenspezifische Discovery-Checklisten | `references/custom/@branche-compliance/discovery-checks.md` | Custom Extension |
 | Neue 5W-Dimensionen | 6W+ in `references/custom/5w-custom.md` (z.B. WIEVIEL für Skalierung) | Custom Extension |
 | Neue EARS-Patterns | `references/custom/ears-patterns-custom.md` | Custom Extension |

--- a/references/custom/@bait/manifest.md
+++ b/references/custom/@bait/manifest.md
@@ -50,8 +50,7 @@ Vor der ersten Prüfung muss die **Perspektive** abgefragt werden:
 
 ## Enthaltene Checklisten
 
-- `checklisten/bait-nfr.md` — 8 Prüfpunkte in 4 Kategorien (Stub)
-  (ITS, IRM, ISM, BBM)
+- `checklisten/bait-nfr.md` — 8 Prüfpunkte in 4 Kategorien (ITS, IRM, ISM, BBM) — Stub
 
 ## Überschneidungen mit anderen Regulierungen
 

--- a/references/templates/constitution-template.md
+++ b/references/templates/constitution-template.md
@@ -5,7 +5,7 @@ Pflichtstruktur für jede `constitution.md`. Verwende bei Projekt-Setup (Modus 1
 ```markdown
 # Project Constitution: [Projektname]
 
-**Version:** [YYYY.MM.DD.N — kalenderbasiert, siehe SKILL.md, Abschnitt Versionierung]
+**Version:** [YYYY.MM.DD.N, siehe SKILL.md, Abschnitt Versionierung]
 **Gültig ab:** [Datum]
 **Verantwortlich:** [Rolle/Name]
 **Letzte Prüfung:** [Datum]

--- a/references/templates/constitution-template.md
+++ b/references/templates/constitution-template.md
@@ -5,7 +5,7 @@ Pflichtstruktur für jede `constitution.md`. Verwende bei Projekt-Setup (Modus 1
 ```markdown
 # Project Constitution: [Projektname]
 
-**Version:** [Semver oder Datum]
+**Version:** [YYYY.MM.DD.N — kalenderbasiert, siehe SKILL.md, Abschnitt Versionierung]
 **Gültig ab:** [Datum]
 **Verantwortlich:** [Rolle/Name]
 **Letzte Prüfung:** [Datum]

--- a/references/templates/spec-template.md
+++ b/references/templates/spec-template.md
@@ -6,7 +6,7 @@ Pflichtstruktur für jede `spec.md`. Verwende bei Spec-Erzeugung (Modus 1, Phase
 # Feature-Spezifikation: [Feature-Name]
 
 **ID:** [Feature-Kürzel, z.B. SF-AUTH]
-**Version:** [Semver oder Datum]
+**Version:** [YYYY.MM.DD.N — kalenderbasiert, siehe SKILL.md, Abschnitt Versionierung]
 **Status:** Draft | In Review | Approved | Superseded
 **Autor:** [Name/Rolle]
 **Erstellt:** [Datum]

--- a/references/templates/spec-template.md
+++ b/references/templates/spec-template.md
@@ -6,7 +6,7 @@ Pflichtstruktur für jede `spec.md`. Verwende bei Spec-Erzeugung (Modus 1, Phase
 # Feature-Spezifikation: [Feature-Name]
 
 **ID:** [Feature-Kürzel, z.B. SF-AUTH]
-**Version:** [YYYY.MM.DD.N — kalenderbasiert, siehe SKILL.md, Abschnitt Versionierung]
+**Version:** [YYYY.MM.DD.N, siehe SKILL.md, Abschnitt Versionierung]
 **Status:** Draft | In Review | Approved | Superseded
 **Autor:** [Name/Rolle]
 **Erstellt:** [Datum]

--- a/scripts/check-checklists.py
+++ b/scripts/check-checklists.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Prueft NFR-Checklisten und Extension-Manifeste gegen das eigene Schema.
+
+CONTRIBUTING-CHECKLISTS.md beschreibt eine Vier-Schritte-Pruefung, die bisher
+nur von Hand abgehakt wurde. Dieses Skript uebernimmt den maschinell
+pruefbaren Teil davon: Schritt 1 (IDs), Schritt 2 (F-Stufen) und Schritt 3
+(Manifest). Schritt 4 bleibt ein Smoke-Test in der Session.
+
+Geprueft wird je Checkliste:
+
+1. Jede Pruefpunkt-Zeile traegt eine ID im Format {KAT}-{NN}, alle IDs einer
+   Datei sind eindeutig und je Kategorie luecklos ab 01 nummeriert. Eine
+   doppelt vergebene ID laesst zwei verschiedene Anforderungen unter
+   derselben Referenz laufen, und genau darauf zeigen Specs und Audit Trail.
+2. Alle Pruefpunkt-Zeilen einer Datei haben gleich viele Spalten, und die
+   letzte Spalte ("Frage an Spec") ist eine Frage.
+3. Es gibt eine F-Stufen-Zuordnungstabelle, sie nennt genau die Kategorien
+   der Checkliste und nur gueltige Stufen F0 bis F5. Die Schreibweise F4
+   und F 4 gilt dabei als gleichwertig, geprueft wird der Wert.
+
+Zusaetzlich je Extension-Paket unter references/custom/@name/:
+
+4. Die manifest.md enthaelt alle Pflicht-Abschnitte.
+5. Die F-Stufen-Tabelle des Manifests deckt jede Perspektive aus dem
+   Perspektiven-Mapping ab und hat die Pflicht-Spalte _default.
+6. Der Abschnitt "Enthaltene Checklisten" nennt Pruefpunkt-Anzahl und
+   Kategorien, und beides stimmt mit der Checkliste ueberein. Das ist die
+   Angabe, die beim Erweitern einer Checkliste zuerst veraltet.
+
+Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
+"""
+
+import os
+import re
+import sys
+
+CHECKPOINT_RE = re.compile(r"^\|\s*([A-Z]{2,5})-(\d{2})\s*\|")
+TABLE_ROW_RE = re.compile(r"^\|(.+)\|\s*$")
+BOLD_CODE_RE = re.compile(r"\*\*([A-Z]{2,5})\*\*")
+F_LEVEL_RE = re.compile(r"\bF\s?(\d)\b")
+BACKTICK_RE = re.compile(r"`([^`]+)`")
+CONTENT_RE = re.compile(
+    r"^- `([^`]+)`\s*[-–—]+\s*(\d+)\s*Prüfpunkte?\s+in\s+"
+    r"(\d+)\s*Kategorien?\s*\(([^)]*)\)")
+
+MANIFEST_SECTIONS = ("Scope", "Trigger-Begriffe", "Trigger-Modi",
+                     "Perspektiven-Mapping", "F-Stufen-Zuordnung",
+                     "Enthaltene Checklisten")
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def read_lines(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read().split("\n")
+
+
+def split_row(line):
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def parse_checkpoints(lines):
+    """Gibt (ids, spaltenzahlen, fehlerhafte_fragen) zurueck."""
+    ids = []
+    widths = set()
+    no_question = []
+    for number, line in enumerate(lines, 1):
+        match = CHECKPOINT_RE.match(line)
+        if not match:
+            continue
+        cells = split_row(line)
+        widths.add(len(cells))
+        ids.append((match.group(1), int(match.group(2)), number))
+        if not cells[-1].endswith("?"):
+            no_question.append((number, cells[-1][:60]))
+    return ids, widths, no_question
+
+
+def find_f_table(lines, start=0):
+    """Sucht die erste Tabelle, deren erste Spalte 'Kategorie' heisst.
+
+    Gibt (spaltenkoepfe, {kategorie: [zellen]}) zurueck.
+    """
+    for index in range(start, len(lines)):
+        row = TABLE_ROW_RE.match(lines[index])
+        if not row:
+            continue
+        header = split_row(lines[index])
+        if not header or header[0].lower() != "kategorie":
+            continue
+        rows = {}
+        cursor = index + 2  # Trennzeile ueberspringen
+        while cursor < len(lines) and TABLE_ROW_RE.match(lines[cursor]):
+            cells = split_row(lines[cursor])
+            code = BOLD_CODE_RE.search(cells[0])
+            if code:
+                rows[code.group(1)] = cells[1:]
+            else:
+                rows[cells[0]] = cells[1:]
+            cursor += 1
+        return header, rows
+    return None, None
+
+
+def check_f_table(label, header, rows, categories, errors):
+    if header is None:
+        errors.append("%s: keine F-Stufen-Tabelle mit Spalte 'Kategorie' "
+                      "gefunden" % label)
+        return
+    listed = set(rows)
+    if listed != categories:
+        missing = sorted(categories - listed)
+        extra = sorted(listed - categories)
+        if missing:
+            errors.append("%s: F-Stufen-Tabelle ohne Kategorie %s"
+                          % (label, ", ".join(missing)))
+        if extra:
+            errors.append("%s: F-Stufen-Tabelle nennt Kategorie %s, die es in "
+                          "der Checkliste nicht gibt" % (label, ", ".join(extra)))
+    for category in sorted(rows):
+        for position, cell in enumerate(rows[category]):
+            levels = F_LEVEL_RE.findall(cell)
+            if not levels:
+                errors.append("%s: F-Stufen-Tabelle, Kategorie %s, Spalte %d "
+                              "ohne F-Stufe" % (label, category, position + 2))
+                continue
+            for level in levels:
+                if int(level) > 5:
+                    errors.append("%s: ungueltige F-Stufe F%s bei Kategorie %s"
+                                  % (label, level, category))
+
+
+def check_checklist(root, rel, errors):
+    lines = read_lines(os.path.join(root, rel))
+    ids, widths, no_question = parse_checkpoints(lines)
+
+    if not ids:
+        errors.append("%s: keine Pruefpunkt-Zeilen gefunden" % rel)
+        return set(), 0
+
+    if len(widths) > 1:
+        errors.append("%s: Pruefpunkt-Zeilen mit unterschiedlicher "
+                      "Spaltenzahl (%s)" % (rel, sorted(widths)))
+    for number, cell in no_question:
+        errors.append("%s:%d: letzte Spalte ist keine Frage: %s"
+                      % (rel, number, cell))
+
+    seen = {}
+    per_category = {}
+    for category, index, number in ids:
+        key = "%s-%02d" % (category, index)
+        if key in seen:
+            errors.append("%s:%d: ID %s ist schon in Zeile %d vergeben"
+                          % (rel, number, key, seen[key]))
+        else:
+            seen[key] = number
+        per_category.setdefault(category, []).append(index)
+
+    for category in sorted(per_category):
+        numbers = per_category[category]
+        expected = list(range(1, len(numbers) + 1))
+        if sorted(numbers) != expected:
+            errors.append("%s: Kategorie %s ist nicht luecklos ab 01 "
+                          "nummeriert (%s)" % (rel, category, numbers))
+
+    categories = set(per_category)
+    header, rows = find_f_table(lines)
+    check_f_table(rel, header, rows, categories, errors)
+    return categories, len(ids)
+
+
+def manifest_sections(lines):
+    return [line.lstrip("#").strip() for line in lines if line.startswith("#")]
+
+
+def parse_perspectives(lines):
+    """Perspective-Werte aus der Tabelle unter 'Perspektiven-Mapping'."""
+    values = []
+    inside = False
+    for line in lines:
+        if line.startswith("#"):
+            inside = "Perspektiven-Mapping" in line
+            continue
+        if not inside or not TABLE_ROW_RE.match(line):
+            continue
+        cells = split_row(line)
+        code = BACKTICK_RE.search(cells[0])
+        if code:
+            values.append(code.group(1))
+    return values
+
+
+def check_manifest(root, package, errors):
+    """Prueft ein Extension-Paket und gibt die deklarierten Checklisten zurueck."""
+    rel = "references/custom/%s/manifest.md" % package
+    path = os.path.join(root, rel)
+    if not os.path.isfile(path):
+        errors.append("%s: manifest.md fehlt" % package)
+        return []
+    lines = read_lines(path)
+
+    headings = manifest_sections(lines)
+    for section in MANIFEST_SECTIONS:
+        if not any(heading.startswith(section) for heading in headings):
+            errors.append("%s: Pflicht-Abschnitt '%s' fehlt" % (rel, section))
+
+    perspectives = parse_perspectives(lines)
+    if not perspectives:
+        errors.append("%s: Perspektiven-Mapping ohne perspective-Werte" % rel)
+
+    start = 0
+    for index, line in enumerate(lines):
+        if line.startswith("#") and "F-Stufen-Zuordnung" in line:
+            start = index
+            break
+    header, rows = find_f_table(lines, start)
+    if header is not None:
+        columns = [cell.strip("` ") for cell in header]
+        for value in perspectives:
+            if value not in columns:
+                errors.append("%s: Perspektive %s fehlt als Spalte in der "
+                              "F-Stufen-Tabelle" % (rel, value))
+        if "_default" not in columns:
+            errors.append("%s: Pflicht-Spalte _default fehlt in der "
+                          "F-Stufen-Tabelle" % rel)
+    else:
+        errors.append("%s: keine F-Stufen-Tabelle gefunden" % rel)
+
+    declared = []
+    inside = False
+    for line in lines:
+        if line.startswith("#"):
+            inside = "Enthaltene Checklisten" in line
+            continue
+        if not inside or not line.startswith("- "):
+            continue
+        entry = CONTENT_RE.match(line)
+        if not entry:
+            errors.append("%s: Eintrag unter 'Enthaltene Checklisten' folgt "
+                          "nicht dem Muster '- `pfad` - N Pruefpunkte in M "
+                          "Kategorien (KAT, ...)': %s" % (rel, line.strip()))
+            continue
+        categories = [item.strip() for item in entry.group(4).split(",")
+                      if item.strip()]
+        declared.append({
+            "manifest": rel,
+            "path": "references/custom/%s/%s" % (package, entry.group(1)),
+            "count": int(entry.group(2)),
+            "category_count": int(entry.group(3)),
+            "categories": set(categories),
+        })
+    if not declared:
+        errors.append("%s: keine Checkliste deklariert" % rel)
+    return declared, rows
+
+
+def main():
+    root = repo_root()
+    errors = []
+    report = []
+
+    core_dir = os.path.join(root, "references", "checklists")
+    core = sorted("references/checklists/" + name
+                  for name in os.listdir(core_dir)
+                  if name.endswith("-nfr.md"))
+    for rel in core:
+        categories, count = check_checklist(root, rel, errors)
+        report.append((rel, count, len(categories), "Core"))
+
+    custom_dir = os.path.join(root, "references", "custom")
+    packages = sorted(name for name in os.listdir(custom_dir)
+                      if name.startswith("@")
+                      and os.path.isdir(os.path.join(custom_dir, name)))
+
+    for package in packages:
+        result = check_manifest(root, package, errors)
+        if not result:
+            continue
+        declared, manifest_rows = result
+        for entry in declared:
+            if not os.path.isfile(os.path.join(root, entry["path"])):
+                errors.append("%s: deklarierte Checkliste fehlt: %s"
+                              % (entry["manifest"], entry["path"]))
+                continue
+            categories, count = check_checklist(root, entry["path"], errors)
+            report.append((entry["path"], count, len(categories), package))
+            if count != entry["count"]:
+                errors.append("%s: Manifest nennt %d Pruefpunkte, die "
+                              "Checkliste hat %d"
+                              % (entry["manifest"], entry["count"], count))
+            if len(categories) != entry["category_count"]:
+                errors.append("%s: Manifest nennt %d Kategorien, die "
+                              "Checkliste hat %d"
+                              % (entry["manifest"], entry["category_count"],
+                                 len(categories)))
+            if entry["categories"] != categories:
+                errors.append("%s: Manifest listet die Kategorien %s, die "
+                              "Checkliste hat %s"
+                              % (entry["manifest"],
+                                 ", ".join(sorted(entry["categories"])),
+                                 ", ".join(sorted(categories))))
+            if manifest_rows is not None and set(manifest_rows) != categories:
+                errors.append("%s: F-Stufen-Tabelle im Manifest deckt %s ab, "
+                              "die Checkliste hat %s"
+                              % (entry["manifest"],
+                                 ", ".join(sorted(manifest_rows)),
+                                 ", ".join(sorted(categories))))
+
+    print("Geprueft: %d Checkliste(n), %d Extension-Paket(e)"
+          % (len(report), len(packages)))
+    for rel, count, categories, origin in report:
+        print("  %-52s %3d Pruefpunkte, %d Kategorien  [%s]"
+              % (rel, count, categories, origin))
+
+    if errors:
+        print("")
+        print("FEHLER (%d):" % len(errors))
+        for message in errors:
+            print("  - %s" % message)
+        return 1
+
+    print("")
+    print("OK: IDs eindeutig, F-Stufen gueltig, Manifest-Angaben stimmen.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-docs-numbers.py
+++ b/scripts/check-docs-numbers.py
@@ -44,7 +44,7 @@ TAG_RE = re.compile(r"<[^>]*>", re.S)
 
 FILES_RE = re.compile(r"(\d+)\s+Dateien\b")
 SUPPORT_RE = re.compile(r"(\d+)\s+Support-Dateien\b")
-MODULE_RE = re.compile(r"(\d+)\s+(?:Fach)?Modul(?:e|en)\b")
+MODULE_RE = re.compile(r"(\d+)\s+(?:[Ff]ach)?[Mm]odul(?:e|en)\b")
 CHECKPOINT_CLAIM_RE = re.compile(r"(\d+)\s+(?:\S*-)?Prüfpunkte\w*")
 LINES_RE = re.compile(r"([\d.]+)\s+Zeilen\b")
 

--- a/scripts/check-docs-numbers.py
+++ b/scripts/check-docs-numbers.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Prueft die Zahlenangaben in README.md und index.html gegen das Repo.
+
+README und Landingpage behaupten Dateizahlen, Modulzahlen und
+Pruefpunktzahlen. Diese Zahlen sind aus dem Repo berechenbar, also werden sie
+berechnet und mit der Behauptung verglichen, statt sie ein weiteres Mal von
+Hand fortzuschreiben. Genau hier lag der Fehler, der die Landingpage
+unglaubwuerdig gemacht hat: "10 Fachmodule + 17 Support-Dateien = 28
+Dateien" war nicht nur veraltet, es ging auch rechnerisch nicht auf.
+
+Berechnet werden:
+
+- Skill-Payload: SKILL.md plus alle Markdown-Dateien unter references/.
+- Fachmodule: references/NN-name.md.
+- Support-Dateien: alle uebrigen Dateien unter references/.
+- Pruefpunkte je Checkliste: Zeilen mit einer ID {KAT}-{NN}.
+
+Geprueft werden alle Vorkommen dieser Muster:
+
+  "<n> Dateien"           gegen die Payload-Zahl
+  "<n> Support-Dateien"   gegen die Zahl der Support-Dateien
+  "<n> Module/Fachmodule" gegen die Zahl der Fachmodule
+  "<n> ...Pruefpunkte"    gegen die Checkliste, die im Text daneben steht
+                          (DORA, BAIT, KRITIS/NIS2)
+
+Zeilenzahlen werden nicht mehr behauptet, weil sie sich mit jeder
+Inhaltsaenderung verschieben. Das Skript meldet es, wenn eine solche Angabe
+zurueckkommt.
+
+Die Versionstabelle im README ist ein Changelog. Was dort steht, beschreibt
+den Stand einer alten Version und wird nicht geprueft.
+
+Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
+"""
+
+import os
+import re
+import sys
+
+MODULE_FILE_RE = re.compile(r"^\d{2}-[a-z0-9-]+\.md$")
+CHECKPOINT_RE = re.compile(r"^\|\s*[A-Z]{2,5}-\d{2}\s*\|", re.M)
+TAG_RE = re.compile(r"<[^>]*>", re.S)
+
+FILES_RE = re.compile(r"(\d+)\s+Dateien\b")
+SUPPORT_RE = re.compile(r"(\d+)\s+Support-Dateien\b")
+MODULE_RE = re.compile(r"(\d+)\s+(?:Fach)?Modul(?:e|en)\b")
+CHECKPOINT_CLAIM_RE = re.compile(r"(\d+)\s+(?:\S*-)?Prüfpunkte\w*")
+LINES_RE = re.compile(r"([\d.]+)\s+Zeilen\b")
+
+# Stichwort im Umfeld einer Pruefpunkt-Zahl -> zustaendige Checkliste.
+CHECKLIST_KEYWORDS = (
+    ("dora", "references/custom/@dora/checklisten/dora-nfr.md"),
+    ("bait", "references/custom/@bait/checklisten/bait-nfr.md"),
+    ("kritis", "references/checklists/kritis-nfr.md"),
+    ("nis2", "references/checklists/kritis-nfr.md"),
+)
+KEYWORD_WINDOW = 120
+
+CHANGELOG_SECTION = "Versionierung"
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def payload_counts(root):
+    modules = []
+    support = []
+    ref_dir = os.path.join(root, "references")
+    for dirpath, dirnames, filenames in os.walk(ref_dir):
+        dirnames.sort()
+        for name in sorted(filenames):
+            if not name.endswith(".md"):
+                continue
+            rel = os.path.relpath(os.path.join(dirpath, name), root)
+            rel = rel.replace(os.sep, "/")
+            if dirpath == ref_dir and MODULE_FILE_RE.match(name):
+                modules.append(rel)
+            else:
+                support.append(rel)
+    return modules, support
+
+
+def checkpoint_counts(root):
+    counts = {}
+    for _, path in CHECKLIST_KEYWORDS:
+        full = os.path.join(root, path)
+        if os.path.isfile(full):
+            counts[path] = len(CHECKPOINT_RE.findall(read(full)))
+    return counts
+
+
+def markdown_segments(text):
+    """Zeilen des README ausserhalb des Changelogs, als (offset-text, zeile)."""
+    segments = []
+    section = ""
+    for number, line in enumerate(text.split("\n"), 1):
+        if line.startswith("## "):
+            section = line[3:].strip()
+        if section == CHANGELOG_SECTION:
+            continue
+        segments.append((line, number))
+    return segments
+
+
+def html_segment(text):
+    """Gibt (text_ohne_tags, zeilennummer_je_zeichen) zurueck."""
+    out = []
+    lines = []
+    line = 1
+    index = 0
+    length = len(text)
+    while index < length:
+        match = TAG_RE.match(text, index)
+        if match:
+            out.append(" ")
+            lines.append(line)
+            line += match.group(0).count("\n")
+            index = match.end()
+            continue
+        char = text[index]
+        out.append(" " if char == "\n" else char)
+        lines.append(line)
+        if char == "\n":
+            line += 1
+        index += 1
+    return "".join(out), lines
+
+
+def nearest_checklist(text, start, end):
+    """Ordnet eine Pruefpunkt-Angabe einer Checkliste zu.
+
+    Zuerst gilt das Stichwort in der Angabe selbst ("41 KRITIS/NIS2-
+    Pruefpunkte"), sonst das naechste Stichwort links davon
+    ("DORA (EU 2022/2554, 58 Pruefpunkte)"). Ein Stichwort rechts der Zahl
+    zaehlt nicht, sonst gewinnt in einer Aufzaehlung die falsche Extension.
+    """
+    inside = text[start:end].lower()
+    for keyword, path in CHECKLIST_KEYWORDS:
+        if keyword in inside:
+            return path
+    before = text[max(0, start - KEYWORD_WINDOW):start].lower()
+    best = None
+    best_position = -1
+    for keyword, path in CHECKLIST_KEYWORDS:
+        position = before.rfind(keyword)
+        if position > best_position:
+            best = path
+            best_position = position
+    return best if best_position >= 0 else None
+
+
+def check_segment(label, text, line_of, expected, counts, errors):
+    """Prueft einen Textabschnitt. line_of(position) liefert die Zeilennummer."""
+    hits = 0
+    for regex, name, value in (
+            (SUPPORT_RE, "Support-Dateien", expected["support"]),
+            (FILES_RE, "Dateien", expected["files"]),
+            (MODULE_RE, "Fachmodule", expected["modules"])):
+        for match in regex.finditer(text):
+            hits += 1
+            claimed = int(match.group(1))
+            if claimed != value:
+                errors.append("%s:%d: %s als %d angegeben, tatsaechlich %d"
+                              % (label, line_of(match.start()), name,
+                                 claimed, value))
+
+    for match in CHECKPOINT_CLAIM_RE.finditer(text):
+        hits += 1
+        claimed = int(match.group(1))
+        path = nearest_checklist(text, match.start(), match.end())
+        if path is None:
+            errors.append("%s:%d: Angabe '%s' ohne erkennbaren Bezug auf eine "
+                          "Checkliste (DORA, BAIT, KRITIS oder NIS2 muss in "
+                          "der Naehe stehen)"
+                          % (label, line_of(match.start()),
+                             match.group(0).strip()))
+            continue
+        value = counts.get(path)
+        if value is None:
+            errors.append("%s:%d: Checkliste %s fehlt im Repo"
+                          % (label, line_of(match.start()), path))
+        elif claimed != value:
+            errors.append("%s:%d: %d Pruefpunkte angegeben, %s hat %d"
+                          % (label, line_of(match.start()), claimed, path,
+                             value))
+
+    for match in LINES_RE.finditer(text):
+        errors.append("%s:%d: Zeilenzahl '%s' wird behauptet. Zeilenzahlen "
+                      "aendern sich mit jeder Inhaltsaenderung und werden "
+                      "hier nicht gefuehrt."
+                      % (label, line_of(match.start()), match.group(0).strip()))
+    return hits
+
+
+def main():
+    root = repo_root()
+    modules, support = payload_counts(root)
+    counts = checkpoint_counts(root)
+    expected = {
+        "files": 1 + len(modules) + len(support),
+        "modules": len(modules),
+        "support": len(support),
+    }
+
+    errors = []
+    checked = 0
+
+    readme = read(os.path.join(root, "README.md"))
+    for line, number in markdown_segments(readme):
+        checked += check_segment("README.md", line, lambda _pos, n=number: n,
+                                 expected, counts, errors)
+
+    html = read(os.path.join(root, "index.html"))
+    flat, line_map = html_segment(html)
+    checked += check_segment("index.html", flat,
+                             lambda pos: line_map[pos], expected, counts,
+                             errors)
+
+    print("Skill-Payload:           %d Dateien (SKILL.md + references/)"
+          % expected["files"])
+    print("  Fachmodule:            %d" % expected["modules"])
+    print("  Support-Dateien:       %d" % expected["support"])
+    for path in sorted(counts):
+        print("Pruefpunkte %-46s %d" % (path, counts[path]))
+    print("Gepruefte Zahlenangaben: %d in README.md und index.html" % checked)
+
+    if errors:
+        print("")
+        print("FEHLER (%d):" % len(errors))
+        for message in errors:
+            print("  - %s" % message)
+        return 1
+
+    print("")
+    print("OK: alle geprueften Zahlenangaben stimmen mit dem Repo ueberein.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-docs-numbers.py
+++ b/scripts/check-docs-numbers.py
@@ -28,8 +28,8 @@ Zeilenzahlen werden nicht mehr behauptet, weil sie sich mit jeder
 Inhaltsaenderung verschieben. Das Skript meldet es, wenn eine solche Angabe
 zurueckkommt.
 
-Die Versionstabelle im README ist ein Changelog. Was dort steht, beschreibt
-den Stand einer alten Version und wird nicht geprueft.
+Die Versionsgeschichte steht in CHANGELOG.md und wird nicht geprueft. Was
+dort steht, beschreibt den Stand einer alten Version und bleibt so stehen.
 
 Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
 """
@@ -56,8 +56,6 @@ CHECKLIST_KEYWORDS = (
     ("nis2", "references/checklists/kritis-nfr.md"),
 )
 KEYWORD_WINDOW = 120
-
-CHANGELOG_SECTION = "Versionierung"
 
 
 def repo_root():
@@ -97,16 +95,9 @@ def checkpoint_counts(root):
 
 
 def markdown_segments(text):
-    """Zeilen des README ausserhalb des Changelogs, als (offset-text, zeile)."""
-    segments = []
-    section = ""
-    for number, line in enumerate(text.split("\n"), 1):
-        if line.startswith("## "):
-            section = line[3:].strip()
-        if section == CHANGELOG_SECTION:
-            continue
-        segments.append((line, number))
-    return segments
+    """Zeilen des README als (zeilentext, zeilennummer)."""
+    return [(line, number)
+            for number, line in enumerate(text.split("\n"), 1)]
 
 
 def html_segment(text):

--- a/scripts/check-frontmatter.py
+++ b/scripts/check-frontmatter.py
@@ -18,7 +18,8 @@ Geprueft wird:
    Der Block-Skalar (description: >) wird dabei zusammengefaltet gezaehlt,
    also so, wie der Wert nach dem Parsen aussieht.
 4. Nur bekannte Schluessel. Ein Tippfehler wie "descripton" wuerde sonst
-   dazu fuehren, dass der Skill ohne Beschreibung ausgeliefert wird.
+   dazu fuehren, dass der Skill ohne Beschreibung ausgeliefert wird. Kommt
+   ein neuer Schluessel legitim dazu, gehoert er in KNOWN_KEYS.
 5. Keine Tabulatoren im Frontmatter. YAML verbietet sie zur Einrueckung.
 
 Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
@@ -33,7 +34,8 @@ KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
 
 NAME_MAX = 64
 DESCRIPTION_MAX = 1024
-KNOWN_KEYS = ("name", "description", "license", "allowed-tools")
+KNOWN_KEYS = ("name", "description", "license", "allowed-tools",
+              "metadata", "version", "compatibility")
 REQUIRED_KEYS = ("name", "description")
 
 

--- a/scripts/check-frontmatter.py
+++ b/scripts/check-frontmatter.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Prueft das YAML-Frontmatter von SKILL.md gegen die Skill-Konventionen.
+
+Claude laedt einen Skill ueber das Frontmatter. Ein grossgeschriebener oder
+mit Leerzeichen versehener name macht den Skill unauffindbar, eine zu lange
+description wird abgeschnitten, und ein unbekannter Schluessel faellt erst
+beim Laden auf. Alles davon ist ein Ein-Zeichen-Fehler in einer Datei, die
+sonst niemand systematisch liest.
+
+Geprueft wird:
+
+1. Die Datei beginnt mit einem Frontmatter-Block, der mit --- oeffnet und
+   mit --- schliesst.
+2. name ist vorhanden, klein geschrieben, nur a-z, 0-9 und Bindestrich,
+   hoechstens 64 Zeichen.
+3. description ist vorhanden, nicht leer und hoechstens 1024 Zeichen lang.
+   Der Block-Skalar (description: >) wird dabei zusammengefaltet gezaehlt,
+   also so, wie der Wert nach dem Parsen aussieht.
+4. Nur bekannte Schluessel. Ein Tippfehler wie "descripton" wuerde sonst
+   dazu fuehren, dass der Skill ohne Beschreibung ausgeliefert wird.
+5. Keine Tabulatoren im Frontmatter. YAML verbietet sie zur Einrueckung.
+
+Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
+"""
+
+import os
+import re
+import sys
+
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
+
+NAME_MAX = 64
+DESCRIPTION_MAX = 1024
+KNOWN_KEYS = ("name", "description", "license", "allowed-tools")
+REQUIRED_KEYS = ("name", "description")
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def split_frontmatter(text):
+    """Gibt (frontmatter_zeilen, fehler) zurueck."""
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return None, "SKILL.md beginnt nicht mit einer Zeile ---"
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            return lines[1:index], None
+    return None, "Frontmatter in SKILL.md wird nicht mit --- geschlossen"
+
+
+def parse_frontmatter(lines):
+    """Flacher Parser fuer skalare Werte und Block-Skalare (> und |).
+
+    Reicht fuer Skill-Frontmatter und vermeidet die Abhaengigkeit auf PyYAML,
+    die sonst nur fuer diese eine Datei im Workflow installiert wuerde.
+    """
+    values = {}
+    order = []
+    current = None
+    block = []
+    for raw in lines:
+        if current is not None and (raw.startswith("  ") or not raw.strip()):
+            block.append(raw.strip())
+            continue
+        if current is not None:
+            values[current] = " ".join(part for part in block if part)
+            current = None
+            block = []
+        match = KEY_RE.match(raw)
+        if not match:
+            continue
+        key, rest = match.group(1), match.group(2).strip()
+        order.append(key)
+        if rest in (">", "|", ">-", "|-"):
+            current = key
+            block = []
+        else:
+            values[key] = rest
+    if current is not None:
+        values[current] = " ".join(part for part in block if part)
+    return values, order
+
+
+def main():
+    root = repo_root()
+    path = os.path.join(root, "SKILL.md")
+    if not os.path.isfile(path):
+        print("FEHLER: SKILL.md nicht gefunden")
+        return 1
+
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+
+    lines, error = split_frontmatter(text)
+    if error:
+        print("FEHLER: %s" % error)
+        return 1
+
+    errors = []
+    if any("\t" in line for line in lines):
+        errors.append("Frontmatter enthaelt einen Tabulator")
+
+    values, order = parse_frontmatter(lines)
+
+    for key in REQUIRED_KEYS:
+        if key not in values:
+            errors.append("Pflichtschluessel fehlt: %s" % key)
+
+    for key in order:
+        if key not in KNOWN_KEYS:
+            errors.append("Unbekannter Schluessel im Frontmatter: %s "
+                          "(erlaubt: %s)" % (key, ", ".join(KNOWN_KEYS)))
+
+    duplicates = sorted({key for key in order if order.count(key) > 1})
+    for key in duplicates:
+        errors.append("Schluessel doppelt vergeben: %s" % key)
+
+    name = values.get("name", "")
+    if "name" in values:
+        if not name:
+            errors.append("name ist leer")
+        else:
+            if not NAME_RE.match(name):
+                errors.append("name '%s' verletzt das Muster "
+                              "a-z, 0-9 und Bindestrich, klein geschrieben"
+                              % name)
+            if len(name) > NAME_MAX:
+                errors.append("name ist %d Zeichen lang, erlaubt sind %d"
+                              % (len(name), NAME_MAX))
+
+    description = values.get("description", "")
+    if "description" in values:
+        if not description:
+            errors.append("description ist leer")
+        elif len(description) > DESCRIPTION_MAX:
+            errors.append("description ist %d Zeichen lang, erlaubt sind %d"
+                          % (len(description), DESCRIPTION_MAX))
+
+    print("Frontmatter-Zeilen:      %d" % len(lines))
+    print("Schluessel:              %s" % (", ".join(order) or "keine"))
+    print("name:                    %s" % (name or "-"))
+    print("description:             %d von %d Zeichen"
+          % (len(description), DESCRIPTION_MAX))
+
+    if errors:
+        print("")
+        print("FEHLER (%d):" % len(errors))
+        for message in errors:
+            print("  - %s" % message)
+        return 1
+
+    print("")
+    print("OK: Frontmatter erfuellt name-, description- und Schluessel-Regeln.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Was drin ist

Ein CI-Workflow mit vier Konsistenzpruefungen und die Richtigstellung der Zahlen-, Versions- und Strukturaussagen in README und Landingpage.

## Was die CI prueft

Das Repo ist reines Markdown, es gibt nichts zu kompilieren und nichts auszufuehren. Der Workflow prueft deshalb die Zusammenhaenge, die zwischen den Dateien bestehen und beim Bearbeiten auseinanderlaufen. Jeder Schritt hat einen realistischen Fehlerfall, sonst waere er nicht drin.

**1. Referenzpfade** (`scripts/check-references.py`, aus Welle 2). Alle `references/`-Pfade, die SKILL.md und die Module nennen. 19 Core-Pfade muessen existieren, 21 Erweiterungspunkte unter `references/custom/` duerfen fehlen, weil sie fuer Nutzer gedacht sind. Dazu die vier als KRITISCH gefuehrten Dateien und die von den Extension-Manifesten deklarierten Checklisten. Rot bei umbenannter Referenzdatei und bei Tippfehlern im Pfad.

**2. Frontmatter von SKILL.md** (`scripts/check-frontmatter.py`). `name` klein geschrieben und ohne Sonderzeichen, `description` unter 1024 Zeichen (aktuell 698), nur bekannte Schluessel, keine Dubletten, keine Tabulatoren. Ein grossgeschriebener `name` macht den Skill unauffindbar, eine zu lange `description` wird abgeschnitten. Beides faellt sonst erst beim Laden auf.

**3. Checklisten und Manifeste** (`scripts/check-checklists.py`). Pruefpunkt-IDs im Format `{KAT}-{NN}`, eindeutig, je Kategorie luecklos ab 01. Gleiche Spaltenzahl in allen Pruefpunkt-Zeilen, letzte Spalte als Frage. F-Stufen-Tabelle deckt genau die Kategorien der Checkliste ab, nur F0 bis F5. Bei Extensions zusaetzlich: Pflicht-Abschnitte im Manifest, jede Perspektive als Spalte, Pflicht-Spalte `_default`, und Uebereinstimmung von Manifest-Angabe und Checkliste bei Pruefpunktzahl, Kategorienzahl und Kategorienamen. Damit ist die Vier-Schritte-Pruefung aus CONTRIBUTING-CHECKLISTS.md zu drei Vierteln automatisiert; Schritt 4 bleibt der Smoke-Test in der Session.

**4. Zahlenangaben in README und index.html** (`scripts/check-docs-numbers.py`). Dateizahl, Modulzahl, Zahl der Support-Dateien und die drei Pruefpunktzahlen werden aus dem Verzeichnisbaum gerechnet und gegen die Behauptung im Text gehalten, 30 Angaben insgesamt. Pruefpunktzahlen werden der Checkliste zugeordnet, deren Stichwort daneben steht. Zeilenzahl-Behauptungen sind verboten, weil sie sich mit jeder Inhaltsaenderung verschieben.

Alles laeuft mit der Standardbibliothek, kein `pip install`. Runner `ubuntu-latest`, `actions/checkout@v4`, `actions/setup-python@v5` mit Python 3.12. Trigger: `push` und `pull_request` auf `main`, dazu `workflow_dispatch`. Alle vier Schritte wurden lokal ausgefuehrt und sind gruen; lokal lief Python 3.9.6 gegen 3.12 in der CI, was bei reiner Standardbibliothek keinen Unterschied macht.

Jeder Schritt wurde ausserdem in einer Kopie des Repos absichtlich gebrochen und war rot: geloeschte Referenzdatei, grossgeschriebener `name`, zu lange `description`, doppelte Pruefpunkt-ID, neuer Pruefpunkt ohne Manifest-Update, neue Kategorie ohne F-Stufen-Zeile, neue Referenzdatei ohne angepasste Dokuzahl.

## Was die CI nicht prueft

- Die erzeugten Artefakte. Ob eine mit SpecForge geschriebene Spec gut ist, sagt der Workflow nicht. Dafuer fehlt beides: ein maschinenlesbares Spec-Format und eine Beispiel-Spec im Repo.
- `course.html`. 1.460 Zeilen Kursmaterial, von nirgends verlinkt, nicht im Scan. Die Zahlen darin sind weiterhin ungeprueft.
- Relative Links. Kein Link-Checker vorhanden.
- Spaltennamen in den Checklisten. `@dora` nutzt `DORA-Artikel` statt des im Schema geforderten `Rechtsquelle`, und die F-Stufen-Tabelle der DORA-Checkliste hat keine `_default`-Spalte. Der Checker toleriert das heute, damit die CI nicht mit einer Inhaltsaenderung an der Referenzimplementierung startet.
- Zeilenzahlen. Bewusst aus der Dokumentation entfernt statt gepflegt.

## Was richtiggestellt wurde

**Dateizahlen.** Die Landingpage rechnete `10 Fachmodule + 17 Support-Dateien = 28 Dateien`. Das geht nicht auf, und die Zahlen stimmten auch nicht. Nachgezaehlt: SKILL.md plus 23 Dateien unter `references/`, also 24, davon 10 Fachmodule und 13 Support-Dateien. Korrigiert an neun Stellen in `index.html` und drei im README, dazu die Statistik-Kacheln und der Hero-Badge, die zwei verschiedene Zahlen zeigten.

**Zeilenzahlen.** Standen an sieben Stellen mit vier verschiedenen Werten, und die Einzelwerte im Architektur-Baum waren durchweg um eins bis sieben daneben. Ersatzlos raus.

**Versionierung.** Vier Schemata liefen nebeneinander. Jetzt zwei, jedes fuer genau einen Gegenstand: die Skill-Version als `MAJOR.MINOR`, die Artefakt-Version als `YYYY.MM.DD.N`, wie SKILL.md es vorschreibt. Die beiden Pflicht-Templates stellten das bisher als "Semver oder Datum" frei und widersprachen damit der eigenen Regel. Die Zeile zu `v<YYMM>-green` beschrieb einen Audit-Status, keine Version, und faellt weg.

**Weitere Falschaussagen in index.html.** Die Phase Gates heissen G0-G5 plus G0-RE bis G4-RE, nicht G0-G8; die G0-G8-Fassung stand ausgerechnet im JSON-LD, das Suchmaschinen auslesen. Der Wechsel auf die modulare Architektur geschah laut Changelog in v3.0, nicht in v3.2.

**README-Struktur.** Von 500 auf 419 Zeilen. "Eigenen Skill nach diesem Muster erstellen" liegt in `docs/skill-als-blaupause.md`, "Quellen und Einfluesse" in `docs/quellen-und-einfluesse.md`, die Versionsgeschichte wortgleich in `CHANGELOG.md`. Neu sind ein Abschnitt **Grenzen**, der sagt, was der Skill nicht leistet, und eine **Roadmap**. Modus 10 Derive war im Verwendungsteil nicht beschrieben und ist ergaenzt.

## Was offen bleibt

- **Zwei Schweregrad-Dialekte.** `enforcement-engine.md` und Modus 10 arbeiten mit F-Stufen, sechs aeltere Module noch mit BLOCKER/MAJOR/MINOR (`08-management.md`: 0 F-Stufen gegen 37 Legacy-Treffer, `09-discover.md`: 0 gegen 34). Das Legacy-Mapping deckt drei der sechs Stufen ab. Im Abschnitt Grenzen benannt, Punkt 1 der Roadmap. Solange das offen ist, kann kein Checker verlaessliche Schweregrade erwarten.
- **@dora haelt das eigene Schema nicht ein.** Spaltenname, `_default` in der Checkliste, `F 4` statt `F4`. Die Extension ist in CONTRIBUTING-CHECKLISTS.md als Referenzimplementierung ausgewiesen, also erben MaRisk, PCI-DSS und EnWG die Abweichungen, wenn niemand sie vorher bereinigt.
- **Kein Versionsfeld im Frontmatter.** Der Payload traegt seine Version nirgends. `check-frontmatter.py` akzeptiert `version` bereits, falls jemand es setzt.
- **Keine Spec im Repo.** Ohne Beispiel-Spec gibt es nichts, woran sich ein spaeterer Spec-Linter messen liesse. Punkt 2 der Roadmap.
- **Kein Release, kein Tag, kein Paket.** Punkt 5 der Roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk

## Wie dieser Branch entstanden ist

Drei Durchgaenge, jeder mit eigener Abnahme:

1. CI anlegen und die im Haerteplan gelisteten Falschaussagen korrigieren.
2. Die Abnahme hat die CI selbst nachgefahren, absichtlich gebrochen, um zu pruefen ob sie Zaehne
   hat, und dabei 9 weitere Aussagen gefunden, die immer noch nicht stimmten. Die wurden im
   zweiten Durchgang korrigiert.
3. Die Nachpruefung des zweiten Durchgangs fand Formulierungen, die beim Korrigieren zu weit
   gingen oder eine neue Ungenauigkeit einfuehrten. Die wurden im dritten Durchgang praezisiert.

Jede Zahl in den geaenderten Texten ist gegen das Repo gemessen, nicht uebernommen.

## Zur CI

Die CI prueft nur, was heute wirklich pruefbar ist. Sie wurde absichtlich gebrochen, um zu
belegen, dass ein realistischer Fehler sie rot macht. Was sie nicht abdeckt, steht in der
Beschreibung der einzelnen Schritte.


---
**Gestapelt.** Dieser PR sitzt auf `fix/welle-2`. GitHub haengt ihn automatisch auf `main` um, sobald der darunterliegende PR gemergt ist. Vorher zeigt der Diff nur die Welle-3-Aenderungen, das ist so gewollt.

Teil von Welle 3 des Haerteplans: CI sichtbar und Claims ehrlich. Jede Aenderung wurde von einem zweiten Durchgang abgenommen, der die CI-Schritte selbst nachgefahren und die CI absichtlich gebrochen hat.
