### PR TITLE
Release-Kette: Packaging-Skript und Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,12 @@ jobs:
 
       - name: Zahlenangaben in README und Landingpage pruefen
         run: python scripts/check-docs-numbers.py
+
+      - name: Versionsangaben und Artefaktname pruefen
+        run: python scripts/check-version.py
+
+      - name: Release-Artefakt bauen
+        run: python scripts/package-skill.py dist/specforge-skill.zip
+
+      - name: Release-Artefakt pruefen
+        run: python scripts/check-package.py dist/specforge-skill.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+# Ein Tag v* baut das Artefakt und haengt es an das Release. Die
+# Packaging-Logik steht bewusst nicht hier, sondern in scripts/, damit sie
+# ohne Tag und ohne GitHub laeuft und die CI sie bei jedem Lauf mitprueft.
+# Dieser Workflow ruft nur auf.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  artefakt:
+    name: Artefakt bauen und anhaengen
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository auschecken
+        uses: actions/checkout@v4
+
+      - name: Python bereitstellen
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Artefakt bauen
+        run: python scripts/package-skill.py dist/specforge-skill.zip
+
+      - name: Artefakt pruefen
+        run: python scripts/check-package.py dist/specforge-skill.zip
+
+      - name: Release anlegen und Artefakt anhaengen
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/specforge-skill.zip
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Tag gegen die Versionsquelle pruefen
+        env:
+          TAG: ${{ github.ref_name }}
+        run: python scripts/check-version.py --tag "$TAG"
+
       - name: Artefakt bauen
         run: python scripts/package-skill.py dist/specforge-skill.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Thumbs.db
 *~
 .idea/
 .vscode/
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Abschnitt Versionierung.
 
 ---
 
+## Aktuelles Release
+
+Diese Tabelle ist die Versionsquelle des Repos. Gelesen wird die erste
+Datenzeile, ein neues Release kommt darüber. Niemand pflegt die Version ein
+zweites Mal: das Packaging-Skript schreibt sie ins Archiv, der
+Release-Workflow vergleicht den Tag damit, und `scripts/check-version.py`
+prüft README und Landingpage dagegen.
+
+| Tag | Skill-Version | Artefakt |
+|-----|---------------|----------|
+| `v3.2.0` | 3.2 | `specforge-skill.zip` |
+
+Der Tag hat eine Stelle mehr als die Skill-Version: `v{MAJOR}.{MINOR}.{PATCH}`.
+Die Patch-Stelle zählt Korrekturen, die den Funktionsumfang nicht verändern.
+`v3.2.0` paketiert den Stand der Skill-Version 3.2 und ist das erste Release
+dieses Repos. Der Artefaktname bleibt über Releases hinweg gleich, damit
+`releases/latest/download/specforge-skill.zip` dauerhaft auf das jeweils
+aktuelle Paket zeigt.
+
+## Versionsgeschichte
+
+Älteste Version zuerst.
+
 | Version | Datum | Änderung |
 |---------|-------|---------|
 | 1.0 | 2025-10 | Initial: Specify, Plan, Tasks, Review, Stakeholder-Sim, Management |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ SpecForge ist ein Claude-Skill (Cowork Plugin / Project Knowledge), der Requirem
 
 ## Installation
 
+Der Skill ist ein Ordner. Es gibt zwei Wege, an ihn zu kommen; ab dann sind die
+drei Varianten gleich.
+
+**Aus dem Release-Archiv:**
+
+```bash
+curl -L -O https://github.com/GodModeAI2025/specforge-ai-skill/releases/latest/download/specforge-skill.zip
+unzip specforge-skill.zip
+```
+
+Das ergibt den Ordner `specforge/` mit `SKILL.md`, `references/`, `LICENSE`,
+`TRADEMARK.md`, einer `VERSION` und einem README, das ohne das Repo auskommt.
+Der Dateiname bleibt über Releases hinweg gleich, `releases/latest/download/`
+zeigt also immer auf das aktuelle Paket. Der Link greift ab dem ersten
+veröffentlichten Tag; solange keiner gesetzt ist, antwortet GitHub mit 404.
+Gebaut wird das Archiv von `scripts/package-skill.py`, das auch lokal läuft.
+
+**Aus dem Repository:** klonen und `SKILL.md` samt `references/` als Ordner
+verwenden. Diesen Weg nimmt, wer am Skill selbst arbeitet.
+
 ### Variante 1: Claude.ai — Als Projekt-Knowledge
 
 1. Öffne ein Claude-Projekt unter [claude.ai](https://claude.ai)
@@ -350,7 +370,7 @@ SpecForge ist Prompt-Text, kein Programm. Daraus folgen Grenzen, die keine Versi
 - **Enforcement wirkt nur in der Session.** Phase Gates, F-Stufen und Anti-Pattern-Erkennung greifen, solange Claude den Skill geladen hat. Es gibt keinen Linter, der eine fertige `spec.md` außerhalb der Session prüft, und keinen Exit-Code für eine Pipeline.
 - **Zwei Schweregrad-Dialekte nebeneinander.** `enforcement-engine.md` und Modus 10 arbeiten mit F-Stufen, mehrere ältere Module noch mit BLOCKER/MAJOR/MINOR. Das Mapping am Ende von `references/checklists/kritis-nfr.md` deckt drei der sechs Stufen ab. Solange das so ist, hängt die gemeldete Stufe davon ab, welches Modul antwortet.
 - **Keine Rechtsberatung.** Die KRITIS-, DORA- und BAIT-Checklisten sind Arbeitshilfen mit Verweis auf die Rechtsquelle. Sie ersetzen keine aufsichtsrechtliche Prüfung. `@bait` ist ausdrücklich ein Stub.
-- **Kein Release-Artefakt.** Kein Tag, kein Paket, kein Download. Installation heißt: Verzeichnis kopieren.
+- **Das Paket ist ein Archiv aus Markdown.** Es installiert nichts und aktualisiert sich nicht. Ein kopierter Ordner erfährt nicht, dass es ein neueres Release gibt; der Abgleich läuft über die `VERSION` im Paket gegen die Releases im Repository.
 - **Deutsch als Arbeitssprache.** Der Skill antwortet englisch auf englische Eingaben, die Referenzdateien und Checklisten bleiben deutsch.
 
 ---
@@ -363,7 +383,7 @@ Offen, in dieser Reihenfolge:
 2. **Beispiel-Spezifikationen ins Repo:** hier liegen nur Templates und Eingabe-Prompts, keine fertige Spec, an der sich ein Ergebnis messen ließe.
 3. **`@bait` vervollständigen:** vom Stub auf die Kapitel der BaFin-Rundschreiben 10/2017 (BA) und 10/2021 (BA).
 4. **Weitere Regulierungen:** MaRisk, PCI-DSS 4.0, EnWG/IT-Sicherheitskatalog. Priorisierung in [CONTRIBUTING-CHECKLISTS.md](CONTRIBUTING-CHECKLISTS.md), Abschnitt 5.
-5. **Release mit Tag:** damit eine Version zitierbar wird und die Landingpage auf etwas Festes zeigen kann.
+5. **Erstes Release veröffentlichen:** Packaging-Skript, Paketprüfung und Release-Workflow liegen im Repo, der Tag `v3.2.0` ist noch nicht gesetzt. Bis dahin läuft `releases/latest/download/` ins Leere.
 6. **Englische Fassung** des Payloads.
 
 ---
@@ -380,12 +400,22 @@ Offen, in dieser Reihenfolge:
 
 ## Versionierung
 
-SpecForge führt zwei Versionen, und nur diese zwei:
+SpecForge führt zwei Versionen, dazu den Tag, unter dem eine davon veröffentlicht wird:
 
 | Gegenstand | Schema | Ort |
 |------------|--------|-----|
-| Skill-Version | `MAJOR.MINOR`, aktuell 3.2 | [CHANGELOG.md](CHANGELOG.md), Badge auf der Landingpage |
+| Skill-Version | `MAJOR.MINOR`, aktuell 3.2 | [CHANGELOG.md](CHANGELOG.md), Abschnitt Aktuelles Release; Badge auf der Landingpage |
+| Release-Tag | `v{MAJOR}.{MINOR}.{PATCH}`, aktuell `v3.2.0` | derselbe Abschnitt; darauf reagiert `.github/workflows/release.yml` |
 | Artefakt-Version | `YYYY.MM.DD.N`, N = laufende Nummer am selben Tag | `version:`-Feld im Header jeder erzeugten `spec.md`, `constitution.md` und `plan.md` |
+
+Der Tag ist keine dritte Version, sondern die Skill-Version mit einer
+Patch-Stelle. Sie zählt Korrekturen, die den Funktionsumfang nicht verändern.
+Ein Funktionsschritt erhöht die Skill-Version, nicht die Patch-Stelle.
+
+Gepflegt wird die Version an genau einer Stelle: in der Tabelle unter
+"Aktuelles Release" in [CHANGELOG.md](CHANGELOG.md). Packaging-Skript und
+Release-Workflow lesen sie dort, `scripts/check-version.py` prüft dieses README,
+die Landingpage und den Artefaktnamen dagegen.
 
 Verbindlich ist die Artefakt-Versionierung in [SKILL.md](SKILL.md), Abschnitt Versionierung. Die Templates unter `references/templates/` geben dasselbe Schema vor. Die früher genannte Schreibweise `v<YYMM>-green` war ein Audit-Status, keine Version, und wird nicht mehr verwendet.
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Die 10 Fachmodule folgen weitgehend derselben Struktur. Wo eine Sektion fehlt od
 
 SpecForge ist Prompt-Text, kein Programm. Daraus folgen Grenzen, die keine Version wegräumt:
 
-- **Die CI prüft den Skill, nicht die Ergebnisse.** Der Workflow in `.github/workflows/ci.yml` hält Referenzpfade, Frontmatter, Checklisten und Zahlenangaben konsistent. Ob eine damit erzeugte Spezifikation fachlich taugt, beurteilt weiterhin ein Mensch.
+- **Die CI prüft den Skill, nicht die Ergebnisse.** Der Workflow in `.github/workflows/ci.yml` hält Referenzpfade, Frontmatter, Checklisten, Zahlen- und Versionsangaben konsistent und baut das Release-Paket bei jedem Lauf, damit ein kaputtes Paket vor dem Tag auffällt. Ob eine damit erzeugte Spezifikation fachlich taugt, beurteilt weiterhin ein Mensch.
 - **Enforcement wirkt nur in der Session.** Phase Gates, F-Stufen und Anti-Pattern-Erkennung greifen, solange Claude den Skill geladen hat. Es gibt keinen Linter, der eine fertige `spec.md` außerhalb der Session prüft, und keinen Exit-Code für eine Pipeline.
 - **Zwei Schweregrad-Dialekte nebeneinander.** `enforcement-engine.md` und Modus 10 arbeiten mit F-Stufen, mehrere ältere Module noch mit BLOCKER/MAJOR/MINOR. Das Mapping am Ende von `references/checklists/kritis-nfr.md` deckt drei der sechs Stufen ab. Solange das so ist, hängt die gemeldete Stufe davon ab, welches Modul antwortet.
 - **Keine Rechtsberatung.** Die KRITIS-, DORA- und BAIT-Checklisten sind Arbeitshilfen mit Verweis auf die Rechtsquelle. Sie ersetzen keine aufsichtsrechtliche Prüfung. `@bait` ist ausdrücklich ein Stub.

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ design/                ← Wireframes, Datenmodelle, Diagramme
 
 ## Skill-Architektur
 
-SpecForge ist als **Multi-File-Skill** aufgebaut: ein Orchestrator (`SKILL.md`) dispatcht zu 10 Fachmodulen und 13 Support-Dateien unter `references/`.
+SpecForge ist als **Multi-File-Skill** aufgebaut: ein Orchestrator (`SKILL.md`) dispatcht zu 10 Fachmodulen und 15 Support-Dateien unter `references/`.
 
 ```
 specforge/
@@ -327,7 +327,7 @@ specforge/
         └── @bait/                    manifest.md + 8 Prüfpunkte, Stub
 ```
 
-**Skill-Payload: 24 Dateien.** Orchestrator + 10 Fachmodule + 13 Support-Dateien. Die Angaben prüft die CI gegen den Verzeichnisbaum, siehe `scripts/check-docs-numbers.py`.
+**Skill-Payload: 26 Dateien.** Orchestrator + 10 Fachmodule + 15 Support-Dateien. Die Angaben prüft die CI gegen den Verzeichnisbaum, siehe `scripts/check-docs-numbers.py`.
 
 ### Warum Multi-File?
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SpecForge — Specs schmieden, nicht schreiben</title>
-  <meta name="description" content="Spec-Driven Requirements Engineering als KI-Skill für Claude. 10 Modi, 15 Methoden, 24 Dateien. F-Stufen (F0–F5), Story-Quality-Score, DORA/BAIT-Extensions, Testfall-Ableitung. Von der Idee zum implementierungsreifen Backlog — oder vom Bestandssystem zurück zur Spec. Open Source.">
+  <meta name="description" content="Spec-Driven Requirements Engineering als KI-Skill für Claude. 10 Modi, 15 Methoden, 26 Dateien. F-Stufen (F0–F5), Story-Quality-Score, DORA/BAIT-Extensions, Testfall-Ableitung. Von der Idee zum implementierungsreifen Backlog — oder vom Bestandssystem zurück zur Spec. Open Source.">
   <meta name="keywords" content="SpecForge, Requirements Engineering, Claude Skill, EARS, Gherkin, STRIDE, KRITIS, NIS2, Spec-Driven Development, AI Skill, Reverse Spec, Bestandsdokumentation, Golden Principles, MECE, Cynefin, MoSCoW, ADR, DDD, Multi-File Skill, Enforcement Engine">
   <meta name="author" content="GodModeAI2025">
   <meta name="robots" content="index, follow">
@@ -12,14 +12,14 @@
   <!-- Open Graph (Facebook, LinkedIn, Perplexity, Slack) -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="SpecForge — Spec-Driven Requirements Engineering als KI-Skill">
-  <meta property="og:description" content="10 Modi, 15 Methoden, 24 Dateien. F-Stufen (F0–F5), DORA/BAIT-Extensions, Story-Quality-Score, Testfall-Ableitung. EARS, Gherkin, STRIDE, KRITIS/NIS2. Enforcement Engine mit Phase Gates. Open Source Claude Skill.">
+  <meta property="og:description" content="10 Modi, 15 Methoden, 26 Dateien. F-Stufen (F0–F5), DORA/BAIT-Extensions, Story-Quality-Score, Testfall-Ableitung. EARS, Gherkin, STRIDE, KRITIS/NIS2. Enforcement Engine mit Phase Gates. Open Source Claude Skill.">
   <meta property="og:url" content="https://godmodeai2025.github.io/specforge-ai-skill/">
   <meta property="og:site_name" content="SpecForge">
   <meta property="og:locale" content="de_DE">
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="SpecForge — Specs schmieden, nicht schreiben">
-  <meta name="twitter:description" content="Spec-Driven Requirements Engineering als KI-Skill für Claude. 10 Modi, 24 Dateien. F-Stufen, DORA-Extensions, Story-Quality-Score, Testfall-Ableitung. Open Source.">
+  <meta name="twitter:description" content="Spec-Driven Requirements Engineering als KI-Skill für Claude. 10 Modi, 26 Dateien. F-Stufen, DORA-Extensions, Story-Quality-Score, Testfall-Ableitung. Open Source.">
   <!-- JSON-LD Structured Data (Google, Perplexity, AI Crawlers) -->
   <script type="application/ld+json">
   {
@@ -28,7 +28,7 @@
     "name": "SpecForge",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Any",
-    "description": "Spec-Driven Requirements Engineering als KI-Skill für Claude. Multi-File-Architektur: Orchestrator (SKILL.md) + 10 Fachmodule + 13 Support-Dateien = 24 Dateien. 10 Modi, 15 etablierte Methoden, F-Stufen (F0–F5), Story-Quality-Score, DORA/BAIT-Extensions, 8 Anti-Patterns, Testfall-Ableitung. Enforcement Engine mit State Machine und Phase Gates. Unterstützt auch Reverse Spec für Bestandsdokumentation.",
+    "description": "Spec-Driven Requirements Engineering als KI-Skill für Claude. Multi-File-Architektur: Orchestrator (SKILL.md) + 10 Fachmodule + 15 Support-Dateien = 26 Dateien. 10 Modi, 15 etablierte Methoden, F-Stufen (F0–F5), Story-Quality-Score, DORA/BAIT-Extensions, 8 Anti-Patterns, Testfall-Ableitung. Enforcement Engine mit State Machine und Phase Gates. Unterstützt auch Reverse Spec für Bestandsdokumentation.",
     "url": "https://godmodeai2025.github.io/specforge-ai-skill/",
     "downloadUrl": "https://github.com/GodModeAI2025/specforge-ai-skill/releases/latest/download/specforge-skill.zip",
     "softwareVersion": "3.2",
@@ -46,7 +46,7 @@
       "Management — 7 Funktionen inkl. Traceability, SFC-Audit, Freshness-Check",
       "Discover — Bestandsdokumentation mit QS-Loops und 5W-Analyse",
       "Derive — Testfall-Ableitung aus Gherkin mit 6 Testfall-Typen und Testabdeckungsmatrix",
-      "Multi-File-Architektur — Orchestrator + 10 Fachmodule + 13 Support-Dateien",
+      "Multi-File-Architektur — Orchestrator + 10 Fachmodule + 15 Support-Dateien",
       "Enforcement Engine — Phase Gates G0-G5 und G0-RE bis G4-RE, F-Stufen (F0–F5), 8 Anti-Patterns",
       "Story-Quality-Score (SQS) — Numerische Formulierungsqualität 0–5",
       "DORA/BAIT-Extensions — Regulatorische Compliance-Erweiterungen",
@@ -331,7 +331,7 @@
       <div class="badges">
         <span class="badge badge-blue">Skill für Claude</span>
         <span class="badge badge-green">v3.2</span>
-        <span class="badge badge-purple">24 Dateien</span>
+        <span class="badge badge-purple">26 Dateien</span>
         <span class="badge badge-orange">10 Modi</span>
       </div>
       <div class="cta-group">
@@ -475,11 +475,11 @@
       <h2 style="font-size:1.5rem;">Multi-File-Architektur</h2>
       <p style="text-align:center; color:var(--text-muted); margin-bottom:24px; font-size:1.05rem;">
         Seit v3.0 liegt SpecForge modular vor statt in einer einzelnen Datei.
-        <strong style="color:var(--text);">Orchestrator + 10 Fachmodule + 13 Support-Dateien.</strong>
+        <strong style="color:var(--text);">Orchestrator + 10 Fachmodule + 15 Support-Dateien.</strong>
       </p>
       <div class="stats">
         <div class="stat">
-          <div class="number">24</div>
+          <div class="number">26</div>
           <div class="label">Dateien</div>
         </div>
         <div class="stat">
@@ -487,7 +487,7 @@
           <div class="label">Fachmodule</div>
         </div>
         <div class="stat">
-          <div class="number">13</div>
+          <div class="number">15</div>
           <div class="label">Support-Dateien</div>
         </div>
         <div class="stat">
@@ -764,7 +764,7 @@ Gherkin-Szenarien ─── Testfall-Ableitung ─── Testabdeckungsmatrix �
   <noscript>
     <section>
       <h2>SpecForge — Zusammenfassung</h2>
-      <p>SpecForge ist ein Open-Source Claude-Skill (v3.2) für Spec-Driven Requirements Engineering mit Governance-Enforcement. Multi-File-Architektur: Orchestrator (SKILL.md) + 10 Fachmodule + 13 Support-Dateien = 24 Dateien. 10 Modi: Specify, Clarify, Plan, Analyze, Checklist, Stakeholder-Simulation, Review, Management, Discover, Derive. 15 etablierte Methoden (Cynefin, Socratic Method, MECE, STRIDE, EARS, Gherkin, DDD, MoSCoW, ADR nach Nygard, Five Whys, Devil's Advocate, Morphological Box, Pugh Matrix, BLUF/Pyramid Principle, Impact Mapping). 10 Golden Principles. F-Stufen-Schweregrade (F0–F5) nach PrüfbV §27. Story-Quality-Score (SQS 0–5). DORA/BAIT-Extensions. 8 Anti-Patterns (inkl. SOPHIST-Verletzung). Testfall-Ableitung (Modus 10 Derive) mit 6 Testfall-Typen und Testabdeckungsmatrix. Enforcement Engine mit State Machine, Phase Gates G0-G5 und G0-RE bis G4-RE, Skip-Protokoll und Anti-Pattern-Erkennung. Wiederkehrende Modul-Sektionen: Fehlerbehandlung und Erzeugte Artefakte in allen zehn Modulen, Profil-Steuerung, Stringenz-Regeln, Erweiterbarkeit und GP-Mapping in sieben oder acht davon. 3 Profile: KRITIS, Standard, Startup. MIT-Lizenz. GitHub: github.com/GodModeAI2025/specforge-ai-skill</p>
+      <p>SpecForge ist ein Open-Source Claude-Skill (v3.2) für Spec-Driven Requirements Engineering mit Governance-Enforcement. Multi-File-Architektur: Orchestrator (SKILL.md) + 10 Fachmodule + 15 Support-Dateien = 26 Dateien. 10 Modi: Specify, Clarify, Plan, Analyze, Checklist, Stakeholder-Simulation, Review, Management, Discover, Derive. 15 etablierte Methoden (Cynefin, Socratic Method, MECE, STRIDE, EARS, Gherkin, DDD, MoSCoW, ADR nach Nygard, Five Whys, Devil's Advocate, Morphological Box, Pugh Matrix, BLUF/Pyramid Principle, Impact Mapping). 10 Golden Principles. F-Stufen-Schweregrade (F0–F5) nach PrüfbV §27. Story-Quality-Score (SQS 0–5). DORA/BAIT-Extensions. 8 Anti-Patterns (inkl. SOPHIST-Verletzung). Testfall-Ableitung (Modus 10 Derive) mit 6 Testfall-Typen und Testabdeckungsmatrix. Enforcement Engine mit State Machine, Phase Gates G0-G5 und G0-RE bis G4-RE, Skip-Protokoll und Anti-Pattern-Erkennung. Wiederkehrende Modul-Sektionen: Fehlerbehandlung und Erzeugte Artefakte in allen zehn Modulen, Profil-Steuerung, Stringenz-Regeln, Erweiterbarkeit und GP-Mapping in sieben oder acht davon. 3 Profile: KRITIS, Standard, Startup. MIT-Lizenz. GitHub: github.com/GodModeAI2025/specforge-ai-skill</p>
     </section>
   </noscript>
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     "operatingSystem": "Any",
     "description": "Spec-Driven Requirements Engineering als KI-Skill für Claude. Multi-File-Architektur: Orchestrator (SKILL.md) + 10 Fachmodule + 13 Support-Dateien = 24 Dateien. 10 Modi, 15 etablierte Methoden, F-Stufen (F0–F5), Story-Quality-Score, DORA/BAIT-Extensions, 8 Anti-Patterns, Testfall-Ableitung. Enforcement Engine mit State Machine und Phase Gates. Unterstützt auch Reverse Spec für Bestandsdokumentation.",
     "url": "https://godmodeai2025.github.io/specforge-ai-skill/",
-    "downloadUrl": "https://github.com/GodModeAI2025/specforge-ai-skill",
+    "downloadUrl": "https://github.com/GodModeAI2025/specforge-ai-skill/releases/latest/download/specforge-skill.zip",
     "softwareVersion": "3.2",
     "license": "https://opensource.org/licenses/MIT",
     "programmingLanguage": "Markdown",
@@ -644,6 +644,13 @@ Gherkin-Szenarien ─── Testfall-Ableitung ─── Testabdeckungsmatrix �
   <section>
     <div class="container">
       <h2>Installation</h2>
+      <p style="text-align:center; color:var(--text-muted); max-width:720px; margin:0 auto 24px;">
+        Der Skill ist ein Ordner. Entweder das Repository klonen oder das Archiv
+        <a href="https://github.com/GodModeAI2025/specforge-ai-skill/releases/latest/download/specforge-skill.zip"><code>specforge-skill.zip</code></a>
+        entpacken. Beides ergibt <code>specforge/</code> mit <code>SKILL.md</code> und
+        <code>references/</code>, danach sind die drei Wege gleich. Der Download-Link
+        greift ab dem ersten veröffentlichten Tag.
+      </p>
       <div class="install-options">
         <div class="install-card">
           <h3>Claude.ai — Projekt-Knowledge</h3>

--- a/packaging/paket-readme.md
+++ b/packaging/paket-readme.md
@@ -1,0 +1,73 @@
+# SpecForge @VERSION@
+
+Spec-Driven Requirements Engineering als Skill für Claude. Dieses Archiv
+enthält den Skill und sonst nichts: den Orchestrator `SKILL.md` und die
+Referenzdateien unter `references/`, die er lädt.
+
+| | |
+|---|---|
+| Version | @VERSION@, auch in `VERSION` |
+| Herkunft | https://github.com/GodModeAI2025/specforge-ai-skill |
+| Lizenz | MIT, siehe `LICENSE` |
+
+## Was hier liegt
+
+```
+specforge/
+├── SKILL.md        Orchestrator: Dispatch auf die Modi, Phase Gates, Pre-Flight
+├── references/     Fachmodule, Checklisten, Templates, Konventionen, Extensions
+├── VERSION         Version dieses Pakets
+├── LICENSE         MIT
+├── TRADEMARK.md    Hinweis zu den genannten Marken
+└── README.md       diese Datei
+```
+
+Der Skill lädt seine Referenzen über relative Pfade ab `references/`. Wer
+einzelne Dateien herauskopiert, muss diese Struktur erhalten, sonst laufen die
+Pfadangaben in `SKILL.md` ins Leere.
+
+## Installation
+
+Entpacken ergibt den Ordner `specforge/`. Er wird als Ganzes kopiert.
+
+### Claude.ai, Projekt-Knowledge
+
+1. Claude-Projekt öffnen und **Project Knowledge** aufrufen
+2. `SKILL.md` und den Inhalt von `references/` hochladen
+
+### Claude Cowork, Plugin/Skill
+
+1. `specforge/` nach `<dein-plugin>/skills/specforge/` kopieren
+2. Den Skill in der `plugin.json` registrieren
+
+### Claude Code, Projekt-Kontext
+
+1. `specforge/` nach `.claude/knowledge/specforge/` legen
+2. In der `CLAUDE.md` darauf verweisen:
+
+   ```markdown
+   ## Knowledge
+   Read .claude/knowledge/specforge/SKILL.md for Requirements Engineering guidance.
+   ```
+
+## Womit zu rechnen ist
+
+- **Prompt-Text, kein Programm.** Der Skill steuert eine Claude-Session. Er
+  installiert nichts und hat keinen Exit-Code.
+- **Enforcement wirkt nur in der Session.** Phase Gates, F-Stufen und
+  Anti-Pattern-Erkennung greifen, solange Claude den Skill geladen hat. Eine
+  fertige `spec.md` prüft danach niemand mehr automatisch.
+- **Kein Updateweg.** Ein kopierter Ordner erfährt nicht, dass es ein neueres
+  Paket gibt. Der Abgleich läuft über die Version in `VERSION` gegen die
+  Releases im Repository.
+- **Keine Rechtsberatung.** Die KRITIS-, DORA- und BAIT-Checklisten sind
+  Arbeitshilfen mit Verweis auf die Rechtsquelle und ersetzen keine
+  aufsichtsrechtliche Prüfung. `@bait` ist ein Stub.
+- **Deutsch als Arbeitssprache.** Auf englische Eingaben antwortet der Skill
+  englisch, die Referenzdateien bleiben deutsch.
+
+## Was nicht im Paket ist
+
+Landingpage, Beispiel-Prompts, Prüfskripte und die Repo-Dokumentation gehören
+nicht zum Skill und sind deshalb nicht enthalten. Sie stehen im Repository.
+Dort laufen auch Issues und Pull Requests.

--- a/scripts/check-package.py
+++ b/scripts/check-package.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Prueft ein gebautes Release-Artefakt, bevor es jemand herunterlaedt.
+
+Aufruf:
+
+    python scripts/check-package.py [pfad]
+
+Ohne Argument wird dist/<Artefaktname aus der Versionsquelle> geprueft.
+
+Die CI ruft dieses Skript bei jedem Lauf hinter package-skill.py auf, der
+Release-Workflow zusaetzlich vor dem Hochladen. Ein kaputtes Paket faellt
+damit auf, bevor jemand ein Tag setzt, nicht danach.
+
+Die Erwartung wird aus dem Repo berechnet, nicht aus dem Bauskript
+uebernommen. Sonst wuerde die Pruefung nur bestaetigen, was das Bauskript
+ohnehin getan hat.
+
+Geprueft wird:
+
+1. Die Datei existiert, ist nicht leer und ist ein lesbares ZIP.
+2. Alle Eintraege liegen unter specforge/. Keine absoluten Pfade, kein
+   "..", keine Verzeichniseintraege, kein leerer Eintrag.
+3. Der Payload stimmt: jede Datei unter references/ ist enthalten, keine
+   zusaetzliche, und die Pflichtdateien SKILL.md, README.md, LICENSE,
+   TRADEMARK.md und VERSION liegen daneben.
+4. Die aus dem Repo uebernommenen Dateien sind Byte fuer Byte identisch.
+   Ein Paket, das eine veraenderte Fassung ausliefert, waere schlimmer als
+   gar keins.
+5. Nichts Verbotenes ist drin: .git, .github, index.html, course.html,
+   Landingpage-Assets, Beispiel-Prompts, Pruefskripte, Repo-Doku.
+6. VERSION und das erzeugte README tragen die Version aus der
+   Versionsquelle, und im README ist kein Platzhalter stehen geblieben.
+7. Keine Mailadressen und kein Schluesselmaterial im Textinhalt.
+
+Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
+"""
+
+import hashlib
+import os
+import re
+import sys
+import zipfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import release_version
+
+PREFIX = "specforge/"
+REQUIRED_TOP = ("LICENSE", "README.md", "SKILL.md", "TRADEMARK.md", "VERSION")
+# Aus dem Repo uebernommen, also unveraendert erwartet.
+COPIED_TOP = ("LICENSE", "SKILL.md", "TRADEMARK.md")
+PAYLOAD_DIR = "references"
+VERSION_PLACEHOLDER = "@VERSION@"
+
+JUNK_NAMES = (".DS_Store", "Thumbs.db", "desktop.ini")
+JUNK_SUFFIXES = (".swp", ".swo", "~", ".orig", ".rej")
+
+# Repo-Innereien und Schluesselmaterial. Geprueft wird der Eintragsname in
+# Kleinschreibung.
+FORBIDDEN_FRAGMENTS = (
+    ".git/", ".github", ".gitignore", "index.html", "course.html",
+    "examples/", "docs/", "scripts/", "packaging/", "contributing",
+    "changelog", ".ds_store", "thumbs.db", ".env", "id_rsa", "id_ed25519",
+    ".pem", ".key", ".p12", ".pfx", "secret", "credential",
+)
+
+MAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+\.[A-Za-z]{2,}")
+KEY_RE = re.compile(
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----|ssh-rsa AAAA|aws_secret_access_key",
+    re.I)
+
+
+def is_junk(name):
+    if name in JUNK_NAMES or name.startswith("."):
+        return True
+    return any(name.endswith(suffix) for suffix in JUNK_SUFFIXES)
+
+
+def expected_payload(root):
+    """Alle references/-Dateien des Repos als Archivnamen."""
+    expected = {}
+    payload_root = os.path.join(root, PAYLOAD_DIR)
+    for dirpath, dirnames, filenames in os.walk(payload_root):
+        dirnames[:] = sorted(d for d in dirnames if not is_junk(d))
+        for name in sorted(filenames):
+            if is_junk(name):
+                continue
+            path = os.path.join(dirpath, name)
+            rel = os.path.relpath(path, root).replace(os.sep, "/")
+            expected[PREFIX + rel] = path
+    return expected
+
+
+def read_bytes(path):
+    with open(path, "rb") as handle:
+        return handle.read()
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(65536), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def main(argv):
+    root = release_version.repo_root()
+    try:
+        release = release_version.read_release(root)
+    except release_version.VersionsquelleFehler as error:
+        print("FEHLER: %s" % error)
+        return 1
+
+    if len(argv) > 2:
+        print("Aufruf: check-package.py [pfad]")
+        return 1
+    target = argv[1] if len(argv) == 2 else os.path.join(
+        root, "dist", release["artifact"])
+
+    if not os.path.isfile(target):
+        print("FEHLER: Artefakt fehlt: %s" % target)
+        return 1
+    size = os.path.getsize(target)
+    if size == 0:
+        print("FEHLER: Artefakt ist leer: %s" % target)
+        return 1
+    if not zipfile.is_zipfile(target):
+        print("FEHLER: Artefakt ist kein lesbares ZIP: %s" % target)
+        return 1
+
+    errors = []
+    if os.path.basename(target) != release["artifact"]:
+        errors.append("Dateiname '%s' weicht vom Artefaktnamen der "
+                      "Versionsquelle ab ('%s')"
+                      % (os.path.basename(target), release["artifact"]))
+
+    with zipfile.ZipFile(target) as archive:
+        broken = archive.testzip()
+        if broken is not None:
+            print("FEHLER: beschaedigter Eintrag im Archiv: %s" % broken)
+            return 1
+        names = archive.namelist()
+        contents = {}
+        for name in names:
+            contents[name] = archive.read(name)
+        sizes = dict((info.filename, info.file_size)
+                     for info in archive.infolist())
+
+    for name in sorted(names):
+        if name.endswith("/"):
+            errors.append("Verzeichniseintrag im Archiv: %s" % name)
+        if name.startswith("/") or ".." in name.split("/") or "\\" in name:
+            errors.append("Unsicherer Pfad im Archiv: %s" % name)
+        if not name.startswith(PREFIX):
+            errors.append("Eintrag liegt nicht unter %s: %s" % (PREFIX, name))
+        if sizes.get(name, 0) == 0:
+            errors.append("Leerer Eintrag im Archiv: %s" % name)
+        lowered = name.lower()
+        for fragment in FORBIDDEN_FRAGMENTS:
+            if fragment in lowered:
+                errors.append("Verbotener Inhalt im Archiv: %s "
+                              "(Muster '%s')" % (name, fragment))
+
+    expected = expected_payload(root)
+    packed_payload = set(n for n in names
+                         if n.startswith(PREFIX + PAYLOAD_DIR + "/"))
+    for name in sorted(set(expected) - packed_payload):
+        errors.append("Payload-Datei fehlt im Archiv: %s" % name)
+    for name in sorted(packed_payload - set(expected)):
+        errors.append("Archiv enthaelt eine Datei, die es unter %s/ nicht "
+                      "gibt: %s" % (PAYLOAD_DIR, name))
+
+    top_level = set(n for n in names
+                    if n.startswith(PREFIX)
+                    and "/" not in n[len(PREFIX):])
+    for name in REQUIRED_TOP:
+        if PREFIX + name not in top_level:
+            errors.append("Pflichtdatei fehlt im Archiv: %s" % (PREFIX + name))
+    for name in sorted(top_level):
+        if name[len(PREFIX):] not in REQUIRED_TOP:
+            errors.append("Unerwartete Datei im Archiv: %s" % name)
+
+    unchanged = 0
+    for name in sorted(set(expected) & packed_payload):
+        if contents[name] != read_bytes(expected[name]):
+            errors.append("Inhalt weicht vom Repo ab: %s" % name)
+        else:
+            unchanged += 1
+    for name in COPIED_TOP:
+        arcname = PREFIX + name
+        source = os.path.join(root, name)
+        if arcname in contents and os.path.isfile(source):
+            if contents[arcname] != read_bytes(source):
+                errors.append("Inhalt weicht vom Repo ab: %s" % arcname)
+            else:
+                unchanged += 1
+
+    version_entry = PREFIX + "VERSION"
+    if version_entry in contents:
+        packed_version = contents[version_entry].decode("utf-8").strip()
+        if packed_version != release["version"]:
+            errors.append("VERSION im Archiv ist '%s', die Versionsquelle "
+                          "sagt '%s'" % (packed_version, release["version"]))
+
+    readme_entry = PREFIX + "README.md"
+    if readme_entry in contents:
+        readme = contents[readme_entry].decode("utf-8")
+        if VERSION_PLACEHOLDER in readme:
+            errors.append("Platzhalter %s steht noch im README des Pakets"
+                          % VERSION_PLACEHOLDER)
+        if release["version"] not in readme:
+            errors.append("README des Pakets nennt die Version %s nicht"
+                          % release["version"])
+
+    mails = []
+    keys = []
+    for name in sorted(names):
+        try:
+            text = contents[name].decode("utf-8")
+        except UnicodeDecodeError:
+            errors.append("Eintrag ist kein UTF-8-Text: %s" % name)
+            continue
+        for match in MAIL_RE.finditer(text):
+            mails.append("%s: %s" % (name, match.group(0)))
+        if KEY_RE.search(text):
+            keys.append(name)
+    for entry in mails:
+        errors.append("Mailadresse im Paket: %s" % entry)
+    for entry in keys:
+        errors.append("Schluesselmaterial im Paket: %s" % entry)
+
+    print("Geprueftes Artefakt:     %s" % target)
+    print("Groesse:                 %d Bytes" % size)
+    print("SHA256:                  %s" % sha256(target))
+    print("Version laut Quelle:     %s (Tag %s)"
+          % (release["version"], release["tag"]))
+    print("Eintraege:               %d" % len(names))
+    print("  Payload references/:   %d von %d erwartet"
+          % (len(packed_payload), len(expected)))
+    print("  Pflichtdateien:        %d von %d"
+          % (len(top_level), len(REQUIRED_TOP)))
+    print("  unveraendert aus Repo: %d" % unchanged)
+    print("Verbotene Muster:        %d geprueft, 0 Treffer erwartet"
+          % len(FORBIDDEN_FRAGMENTS))
+    print("Mailadressen:            %d" % len(mails))
+    print("Schluesselmaterial:      %d" % len(keys))
+
+    if errors:
+        print("")
+        print("FEHLER (%d):" % len(errors))
+        for message in errors:
+            print("  - %s" % message)
+        return 1
+
+    print("")
+    print("OK: Paket vollstaendig, unveraendert und frei von Repo-Innereien.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-version.py
+++ b/scripts/check-version.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Prueft Versionsangaben und Artefaktnamen gegen die Versionsquelle.
+
+Aufruf:
+
+    python scripts/check-version.py
+    python scripts/check-version.py --tag v3.2.0
+
+Die Version steht in CHANGELOG.md, Abschnitt "Aktuelles Release". README,
+Landingpage, Release-Workflow und CI nennen sie erneut, weil ein Mensch sie
+dort lesen will. Genau daraus entsteht der Fehler, den niemand bemerkt: eine
+Stelle wird nachgezogen, die andere nicht. Also wird verglichen.
+
+Geprueft wird:
+
+1. Die Versionsquelle ist lesbar und in sich stimmig (Tag, Skill-Version,
+   Artefaktname).
+2. Die Versionsgeschichte in CHANGELOG.md endet bei der Skill-Version, die
+   das Release paketiert.
+3. README.md nennt dieselbe Skill-Version ("aktuell X.Y") und denselben Tag.
+4. index.html nennt dieselbe Skill-Version an allen vier Stellen, an denen
+   sie steht: JSON-LD, generator-Meta, Badge und Crawler-Zusammenfassung.
+5. Jede Download-URL in README.md und index.html endet auf den
+   Artefaktnamen aus der Versionsquelle. Das ist der Teil, der beim ersten
+   Release schweigend danebengehen wuerde: der Link waere da, das Paket
+   hiesse anders, und der Download bliebe 404.
+6. Die Workflows bauen und pruefen genau diesen Dateinamen, und der
+   Release-Workflow haengt an Tags v*.
+7. Mit --tag: der uebergebene Tag ist der aus der Versionsquelle. Der
+   Release-Workflow ruft das so auf, damit ein vertipptes Tag kein Release
+   erzeugt.
+
+Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import release_version
+
+HISTORY_HEADING = "## Versionsgeschichte"
+SEPARATOR_RE = re.compile(r"^[:\- ]+$")
+HISTORY_VERSION_RE = re.compile(r"^(\d+\.\d+)")
+
+CURRENT_RE = re.compile(r"aktuell (\d+\.\d+)")
+FULL_TAG_RE = re.compile(r"\bv\d+\.\d+\.\d+\b")
+# Nur URLs mit Dateinamen. Die blosse Nennung des Verzeichnisses
+# `releases/latest/download/` im Fliesstext ist kein Artefaktname.
+DOWNLOAD_RE = re.compile(
+    r"releases/(?:latest/)?download/([A-Za-z0-9][A-Za-z0-9._-]*\.[A-Za-z0-9]+)")
+WORKFLOW_ZIP_RE = re.compile(r"dist/([A-Za-z0-9._-]+\.zip)")
+
+# Stellen in index.html, an denen die Skill-Version steht. Fehlt eine, ist
+# die Seite umgebaut worden und die Pruefung muss nachgezogen werden.
+HTML_ANCHORS = (
+    ("JSON-LD softwareVersion",
+     re.compile(r'"softwareVersion"\s*:\s*"([\d.]+)"')),
+    ("generator-Meta",
+     re.compile(r'<meta name="generator" content="SpecForge v([\d.]+)">')),
+    ("Badge im Kopf",
+     re.compile(r'badge-green">v([\d.]+)<')),
+    ("Crawler-Zusammenfassung",
+     re.compile(r'Claude-Skill \(v([\d.]+)\)')),
+)
+
+WORKFLOWS = (
+    os.path.join(".github", "workflows", "ci.yml"),
+    os.path.join(".github", "workflows", "release.yml"),
+)
+
+
+def read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def history_versions(text):
+    """Versionen der Tabelle unter '## Versionsgeschichte', in Reihenfolge."""
+    versions = []
+    inside = False
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            if inside:
+                break
+            inside = stripped == HISTORY_HEADING
+            continue
+        if not inside or not stripped.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if not cells or all(SEPARATOR_RE.match(cell or "-") for cell in cells):
+            continue
+        match = HISTORY_VERSION_RE.match(cells[0])
+        if match:
+            versions.append(match.group(1))
+    return versions
+
+
+def check_all(label, text, regex, expected, what, errors, required=True):
+    """Jeder Treffer muss expected sein, und es muss einen geben."""
+    hits = regex.findall(text)
+    for hit in hits:
+        if hit != expected:
+            errors.append("%s: %s steht als '%s', die Versionsquelle sagt '%s'"
+                          % (label, what, hit, expected))
+    if required and not hits:
+        errors.append("%s: %s nicht gefunden. Wurde die Datei umgebaut, muss "
+                      "check-version.py nachgezogen werden." % (label, what))
+    return len(hits)
+
+
+def main(argv):
+    tag_argument = None
+    rest = argv[1:]
+    if rest[:1] == ["--tag"]:
+        if len(rest) != 2:
+            print("Aufruf: check-version.py [--tag <tag>]")
+            return 1
+        tag_argument = rest[1]
+    elif rest:
+        print("Aufruf: check-version.py [--tag <tag>]")
+        return 1
+
+    root = release_version.repo_root()
+    try:
+        release = release_version.read_release(root)
+    except release_version.VersionsquelleFehler as error:
+        print("FEHLER: %s" % error)
+        return 1
+
+    skill = release["skill_version"]
+    tag = release["tag"]
+    artifact = release["artifact"]
+    errors = []
+    checked = 0
+
+    changelog = read(release_version.changelog_path(root))
+    history = history_versions(changelog)
+    if not history:
+        errors.append("CHANGELOG.md: Abschnitt '%s' ohne Tabellenzeilen"
+                      % HISTORY_HEADING)
+    elif history[-1] != skill:
+        errors.append("CHANGELOG.md: juengster Eintrag der Versionsgeschichte "
+                      "ist %s, das Release paketiert %s"
+                      % (history[-1], skill))
+    checked += 1
+
+    readme = read(os.path.join(root, "README.md"))
+    html = read(os.path.join(root, "index.html"))
+
+    checked += check_all("README.md", readme, CURRENT_RE, skill,
+                         "die Skill-Version", errors)
+    for label, text in (("README.md", readme), ("index.html", html)):
+        for hit in FULL_TAG_RE.findall(text):
+            checked += 1
+            if hit != tag:
+                errors.append("%s: Tag '%s' genannt, die Versionsquelle sagt "
+                              "'%s'" % (label, hit, tag))
+
+    for what, regex in HTML_ANCHORS:
+        checked += check_all("index.html", html, regex, skill, what, errors)
+
+    for label, text in (("README.md", readme), ("index.html", html)):
+        checked += check_all(label, text, DOWNLOAD_RE, artifact,
+                             "der Artefaktname in der Download-URL", errors)
+
+    for relative in WORKFLOWS:
+        path = os.path.join(root, relative)
+        if not os.path.isfile(path):
+            errors.append("Workflow fehlt: %s" % relative)
+            continue
+        workflow = read(path)
+        checked += check_all(relative, workflow, WORKFLOW_ZIP_RE, artifact,
+                             "der gebaute Dateiname", errors)
+        for script in ("scripts/package-skill.py", "scripts/check-package.py"):
+            if script not in workflow:
+                errors.append("%s: ruft %s nicht auf" % (relative, script))
+
+    release_workflow = read(os.path.join(root, WORKFLOWS[1]))
+    if "tags:" not in release_workflow or "'v*'" not in release_workflow:
+        errors.append("%s: reagiert nicht auf push von Tags 'v*'"
+                      % WORKFLOWS[1])
+    if "contents: write" not in release_workflow:
+        errors.append("%s: fehlende Berechtigung contents: write"
+                      % WORKFLOWS[1])
+
+    if tag_argument is not None:
+        checked += 1
+        if tag_argument != tag:
+            errors.append("Uebergebener Tag '%s' passt nicht zur "
+                          "Versionsquelle '%s'" % (tag_argument, tag))
+
+    print("Versionsquelle:          CHANGELOG.md, Abschnitt Aktuelles Release")
+    print("Tag:                     %s" % tag)
+    print("Skill-Version:           %s" % skill)
+    print("Artefakt:                %s" % artifact)
+    print("Versionsgeschichte:      %d Eintraege, zuletzt %s"
+          % (len(history), history[-1] if history else "-"))
+    if tag_argument is not None:
+        print("Uebergebener Tag:        %s" % tag_argument)
+    print("Gepruefte Angaben:       %d in CHANGELOG.md, README.md, "
+          "index.html und den Workflows" % checked)
+
+    if errors:
+        print("")
+        print("FEHLER (%d):" % len(errors))
+        for message in errors:
+            print("  - %s" % message)
+        return 1
+
+    print("")
+    print("OK: Version und Artefaktname stimmen ueberall mit der "
+          "Versionsquelle ueberein.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/package-skill.py
+++ b/scripts/package-skill.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Baut das Release-Artefakt: den Skill-Payload als ZIP.
+
+Aufruf:
+
+    python scripts/package-skill.py dist/specforge-skill.zip
+
+Laeuft lokal, ohne Netz und ohne GitHub. Der Release-Workflow ruft genau
+dieses Skript auf und haengt das Ergebnis an das Release. Damit ist das
+Paket vor dem Tag pruefbar, nicht erst danach.
+
+Was hineinkommt:
+
+- SKILL.md und alles unter references/, also der Payload, den Claude laedt
+- LICENSE und TRADEMARK.md, weil der Payload fremde Marken benennt
+- README.md, erzeugt aus packaging/paket-readme.md, damit der entpackte
+  Ordner fuer sich verstaendlich ist
+- VERSION mit der Version aus der Versionsquelle
+
+Was draussen bleibt: index.html, course.html, .github/, .git/, scripts/,
+docs/, examples/, CHANGELOG und alles weitere Repo-Innere. Der Payload ist
+nicht das Repo.
+
+Reproduzierbarkeit: fester Zeitstempel, feste Rechte, sortierte
+Reihenfolge, kein Zufallsname. Zwei Laeufe hintereinander ergeben dieselbe
+Datei, Byte fuer Byte. Ohne das laesst sich nicht pruefen, ob ein Paket
+inhaltlich vom vorigen abweicht oder nur neu gebaut wurde.
+
+Exit 0 wenn das Paket geschrieben wurde, sonst 1. Nur Standardbibliothek.
+"""
+
+import hashlib
+import os
+import sys
+import zipfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import release_version
+
+PREFIX = "specforge/"
+TOP_FILES = ("SKILL.md", "LICENSE", "TRADEMARK.md")
+PAYLOAD_DIR = "references"
+README_TEMPLATE = os.path.join("packaging", "paket-readme.md")
+VERSION_PLACEHOLDER = "@VERSION@"
+
+# Fester Zeitstempel im Archiv. Kein Bezug zur Bauzeit, sonst waere jedes
+# Paket ein anderes.
+FIXED_DATE = (2026, 1, 1, 0, 0, 0)
+FILE_MODE = 0o644 << 16
+CREATE_SYSTEM_UNIX = 3
+
+# Betriebssystem- und Editor-Reste, die nichts im Paket verloren haben.
+JUNK_NAMES = (".DS_Store", "Thumbs.db", "desktop.ini")
+JUNK_SUFFIXES = (".swp", ".swo", "~", ".orig", ".rej")
+
+
+def is_junk(name):
+    if name in JUNK_NAMES or name.startswith("."):
+        return True
+    return any(name.endswith(suffix) for suffix in JUNK_SUFFIXES)
+
+
+def read_bytes(path):
+    with open(path, "rb") as handle:
+        return handle.read()
+
+
+def collect_repo_files(root):
+    """Gibt [(arcname, quellpfad)] fuer die Dateien aus dem Repo zurueck."""
+    entries = []
+    skipped = []
+    for name in TOP_FILES:
+        path = os.path.join(root, name)
+        if not os.path.isfile(path):
+            raise IOError("Pflichtdatei fehlt: %s" % name)
+        entries.append((PREFIX + name, path))
+
+    payload_root = os.path.join(root, PAYLOAD_DIR)
+    if not os.path.isdir(payload_root):
+        raise IOError("Verzeichnis fehlt: %s/" % PAYLOAD_DIR)
+    for dirpath, dirnames, filenames in os.walk(payload_root):
+        dirnames[:] = sorted(d for d in dirnames if not is_junk(d))
+        for name in sorted(filenames):
+            path = os.path.join(dirpath, name)
+            rel = os.path.relpath(path, root).replace(os.sep, "/")
+            if is_junk(name):
+                skipped.append(rel)
+                continue
+            entries.append((PREFIX + rel, path))
+    return entries, skipped
+
+
+def build_generated(root, release):
+    """Erzeugte Dateien: README.md aus der Vorlage und VERSION."""
+    template_path = os.path.join(root, README_TEMPLATE)
+    if not os.path.isfile(template_path):
+        raise IOError("Vorlage fehlt: %s" % README_TEMPLATE)
+    with open(template_path, encoding="utf-8") as handle:
+        template = handle.read()
+    if VERSION_PLACEHOLDER not in template:
+        raise IOError("Vorlage %s enthaelt kein %s"
+                      % (README_TEMPLATE, VERSION_PLACEHOLDER))
+    readme = template.replace(VERSION_PLACEHOLDER, release["version"])
+    return [
+        (PREFIX + "README.md", readme.encode("utf-8")),
+        (PREFIX + "VERSION", (release["version"] + "\n").encode("utf-8")),
+    ]
+
+
+def write_archive(target, items):
+    """Schreibt das ZIP deterministisch. items ist [(arcname, bytes)]."""
+    directory = os.path.dirname(os.path.abspath(target))
+    if directory and not os.path.isdir(directory):
+        os.makedirs(directory)
+    with zipfile.ZipFile(target, "w", zipfile.ZIP_DEFLATED) as archive:
+        for arcname, data in sorted(items, key=lambda item: item[0]):
+            info = zipfile.ZipInfo(arcname, date_time=FIXED_DATE)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.create_system = CREATE_SYSTEM_UNIX
+            info.external_attr = FILE_MODE
+            archive.writestr(info, data, compresslevel=9)
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(65536), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def main(argv):
+    if len(argv) != 2:
+        print("Aufruf: package-skill.py <ausgabepfad>")
+        print("Beispiel: python scripts/package-skill.py "
+              "dist/specforge-skill.zip")
+        return 1
+    target = argv[1]
+
+    root = release_version.repo_root()
+    try:
+        release = release_version.read_release(root)
+    except release_version.VersionsquelleFehler as error:
+        print("FEHLER: %s" % error)
+        return 1
+
+    try:
+        repo_entries, skipped = collect_repo_files(root)
+        items = [(arcname, read_bytes(path)) for arcname, path in repo_entries]
+        items.extend(build_generated(root, release))
+    except IOError as error:
+        print("FEHLER: %s" % error)
+        return 1
+
+    empty = [arcname for arcname, data in items if not data]
+    if empty:
+        print("FEHLER: leere Datei im Paket: %s" % ", ".join(sorted(empty)))
+        return 1
+
+    write_archive(target, items)
+
+    print("Versionsquelle:          CHANGELOG.md, Abschnitt Aktuelles Release")
+    print("Version:                 %s (Tag %s, Skill-Version %s)"
+          % (release["version"], release["tag"], release["skill_version"]))
+    print("Artefaktname laut Quelle: %s" % release["artifact"])
+    print("Ausgabepfad:             %s" % target)
+    if os.path.basename(target) != release["artifact"]:
+        print("Hinweis:                 Der Dateiname weicht vom Artefaktnamen "
+              "der Versionsquelle ab.")
+    if skipped:
+        print("Uebersprungen:           %s" % ", ".join(skipped))
+    print("Eintraege:               %d" % len(items))
+    for arcname, data in sorted(items, key=lambda item: item[0]):
+        print("  %-52s %7d" % (arcname, len(data)))
+    print("Groesse:                 %d Bytes" % os.path.getsize(target))
+    print("SHA256:                  %s" % sha256(target))
+    print("")
+    print("OK: Paket geschrieben.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Liest die Versionsquelle des Repos aus CHANGELOG.md.
+
+Die Version stand an mehreren Stellen: README, Landingpage, Changelog. Wer
+eine davon vergisst, merkt es nicht, und beim ersten Release faellt es
+gleichzeitig an drei Stellen auf. Deshalb gibt es genau eine gepflegte
+Stelle, den Abschnitt "Aktuelles Release" in CHANGELOG.md, und alles andere
+liest sie oder wird von der CI dagegen geprueft.
+
+Gelesen wird die erste Datenzeile der Tabelle in diesem Abschnitt:
+
+    | Tag      | Skill-Version | Artefakt              |
+    |----------|---------------|-----------------------|
+    | `v3.2.0` | 3.2           | `specforge-skill.zip` |
+
+Neuestes Release steht oben. Der Tag traegt eine Stelle mehr als die
+Skill-Version, die Patch-Stelle zaehlt Korrekturen ohne Funktionsaenderung.
+
+Dieses Modul wird von package-skill.py, check-package.py und
+check-version.py importiert, damit die Zeile nur an einer Stelle geparst
+wird. Direkt aufgerufen gibt es die Werte auf der Standardausgabe aus.
+
+Nur Standardbibliothek.
+"""
+
+import os
+import re
+import sys
+
+HEADING = "## Aktuelles Release"
+COLUMNS = ("Tag", "Skill-Version", "Artefakt")
+
+TAG_RE = re.compile(r"^v(\d+\.\d+)\.(\d+)$")
+SKILL_RE = re.compile(r"^\d+\.\d+$")
+ARTIFACT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*\.zip$")
+SEPARATOR_RE = re.compile(r"^[:\- ]+$")
+
+
+class VersionsquelleFehler(Exception):
+    """Der Abschnitt fehlt, ist leer oder haelt sich nicht an das Format."""
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def changelog_path(root=None):
+    return os.path.join(root or repo_root(), "CHANGELOG.md")
+
+
+def _cells(line):
+    """Tabellenzeile in Zellen zerlegen, Backticks und Leerraum weg."""
+    stripped = line.strip()
+    if not stripped.startswith("|"):
+        return None
+    parts = stripped.strip("|").split("|")
+    return [part.strip().strip("`").strip() for part in parts]
+
+
+def _section_rows(text):
+    """Gibt (ueberschrift_gefunden, tabellenzeilen) zurueck.
+
+    Gelesen wird nur der Abschnitt unter HEADING, bis zur naechsten
+    Ueberschrift derselben Ebene.
+    """
+    rows = []
+    found = False
+    inside = False
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            if inside:
+                break
+            inside = stripped == HEADING
+            found = found or inside
+            continue
+        if not inside:
+            continue
+        cells = _cells(line)
+        if cells:
+            rows.append(cells)
+    return found, rows
+
+
+def read_release(root=None):
+    """Gibt {tag, version, skill_version, artifact} aus CHANGELOG.md zurueck."""
+    path = changelog_path(root)
+    if not os.path.isfile(path):
+        raise VersionsquelleFehler("CHANGELOG.md fehlt: %s" % path)
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+
+    seen, rows = _section_rows(text)
+    if not seen:
+        raise VersionsquelleFehler(
+            "CHANGELOG.md hat keinen Abschnitt '%s'" % HEADING)
+
+    data = [row for row in rows
+            if not all(SEPARATOR_RE.match(cell or "-") for cell in row)]
+    if not data:
+        raise VersionsquelleFehler(
+            "Abschnitt '%s' enthaelt keine Tabellenzeile" % HEADING)
+
+    header = data[0]
+    if tuple(header[:3]) != COLUMNS:
+        raise VersionsquelleFehler(
+            "Kopfzeile der Release-Tabelle lautet %s, erwartet %s"
+            % (tuple(header[:3]), COLUMNS))
+    if len(data) < 2:
+        raise VersionsquelleFehler(
+            "Abschnitt '%s' hat eine Kopfzeile, aber keine Datenzeile"
+            % HEADING)
+
+    row = data[1]
+    if len(row) < 3:
+        raise VersionsquelleFehler(
+            "Erste Datenzeile hat %d Spalten, erwartet 3" % len(row))
+    tag, skill_version, artifact = row[0], row[1], row[2]
+
+    match = TAG_RE.match(tag)
+    if not match:
+        raise VersionsquelleFehler(
+            "Tag '%s' entspricht nicht dem Muster v{MAJOR}.{MINOR}.{PATCH}"
+            % tag)
+    if not SKILL_RE.match(skill_version):
+        raise VersionsquelleFehler(
+            "Skill-Version '%s' entspricht nicht dem Muster MAJOR.MINOR"
+            % skill_version)
+    if match.group(1) != skill_version:
+        raise VersionsquelleFehler(
+            "Tag '%s' und Skill-Version '%s' passen nicht zusammen"
+            % (tag, skill_version))
+    if not ARTIFACT_RE.match(artifact):
+        raise VersionsquelleFehler(
+            "Artefaktname '%s' ist kein einfacher Dateiname mit Endung .zip"
+            % artifact)
+
+    return {
+        "tag": tag,
+        "version": tag[1:],
+        "skill_version": skill_version,
+        "artifact": artifact,
+    }
+
+
+def main():
+    try:
+        release = read_release()
+    except VersionsquelleFehler as error:
+        print("FEHLER: %s" % error)
+        return 1
+    print("Tag:                     %s" % release["tag"])
+    print("Version:                 %s" % release["version"])
+    print("Skill-Version:           %s" % release["skill_version"])
+    print("Artefakt:                %s" % release["artifact"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Release-Kette fuer das erste Release

Das Repo hat bisher kein Artefakt und keine Version, die irgendwo gelesen wird. Dieser Branch legt beides an, ohne ein Tag zu setzen. Das macht der Owner.

### Was dazukommt

**Packaging-Skript statt Shell im Workflow.** `scripts/package-skill.py <ausgabepfad>` baut `specforge-skill.zip` aus SKILL.md und references/, dazu LICENSE, TRADEMARK.md, ein eigenes README fuer den entpackten Ordner und eine VERSION. Es laeuft lokal, ohne Netz und ohne GitHub. Ein Workflow mit eingebetteter Packaging-Logik liesse sich nur pruefen, indem man ein Tag setzt; ein Skript prueft die CI bei jedem Lauf mit.

**Reproduzierbar.** Fester Zeitstempel, feste Rechte, sortierte Reihenfolge, keine Version im Dateinamen. Zwei Laeufe ergeben dieselbe Datei: SHA256 `eae6ae88…`, identisch ueber Zeitzonenwechsel, geaenderte Dateizeiten, Arbeitsverzeichnis gegen frischen Klon und Python 3.9 gegen 3.13. Nicht geprueft ist Byte-Gleichheit gegen ubuntu-latest, dort laeuft eine andere zlib.

**Paketpruefung.** `scripts/check-package.py` prueft ein gebautes Archiv gegen das Repo: alle 23 Referenzdateien vorhanden und Byte fuer Byte gleich, Pflichtdateien daneben, kein Eintrag ausserhalb `specforge/`, kein leerer Eintrag, keine Verzeichnistricks. Verboten sind .git, .github, index.html, course.html, examples/, docs/, die Pruefskripte, dazu Mailadressen und Schluesselmaterial im Text. Die Erwartung berechnet das Skript aus dem Repo, nicht aus dem Bauskript, sonst wuerde es nur bestaetigen, was das Bauskript ohnehin getan hat. Neun manipulierte Archive fallen durch, darunter mitgepackte Landingpage, mitgepackter Workflow und veraenderte SKILL.md.

**Release-Workflow.** `.github/workflows/release.yml` reagiert auf push von Tags `v*`, prueft das Tag gegen die Versionsquelle, ruft die beiden Skripte auf und haengt das Archiv mit `softprops/action-gh-release@v2` an. `permissions: contents: write`, `fail_on_unmatched_files: true`, damit ein fehlendes Archiv kein stiller Erfolg wird. Packaging-Logik steht nicht im Workflow.

**Versionsquelle.** Die Version stand in README, Landingpage und Changelog nebeneinander; mit Tag und Artefaktname waeren es fuenf Stellen geworden. Gepflegt wird sie jetzt in `CHANGELOG.md`, Abschnitt "Aktuelles Release": Tag, Skill-Version, Artefaktname. `scripts/release_version.py` liest diese eine Zeile, alle anderen Skripte importieren sie. `scripts/check-version.py` vergleicht sie mit README, Landingpage, Versionsgeschichte und beiden Workflows und faellt auch dann auf, wenn ein Umbau der Landingpage eine der vier Versionsangaben entfernt.

**Doku.** README und Landingpage nennen den Download aus `releases/latest/download/specforge-skill.zip`, Zeichen fuer Zeichen den Namen, den das Skript erzeugt; check-version.py haelt das fest. Der Ordnerweg bleibt unangetastet: ein Skill, den man als Ordner kopieren kann, soll das bleiben. Dass der Link erst ab dem ersten veroeffentlichten Tag greift, steht dabei. Nachgezogen sind die Stellen, die durch das Release nicht mehr stimmten: die Grenze "Kein Release-Artefakt", die Aufzaehlung dessen, was die CI leistet, der Roadmap-Punkt und der Abschnitt Versionierung.

### Warum v3.2.0 und nicht v3.3.0

Seit 3.2 gab es keinen Funktionsschritt. Welle 2 hat Beschreibungen an die gebauten Module angeglichen, Welle 3 hat Pruefskripte ergaenzt. 3.3 wuerde einen Schritt behaupten, den es nicht gab. Zugleich wurde 3.2 nie veroeffentlicht, es gibt also kein aelteres Artefakt, gegen das der Tag sich abgrenzen muesste. Der Tag traegt deshalb eine dritte Stelle, `v{MAJOR}.{MINOR}.{PATCH}`; sie nimmt die Korrekturen auf, ohne die Skill-Version anzufassen. README und index.html behalten damit ihre 3.2, und die Zahlenpruefung aus Welle 3 bleibt unberuehrt.

### Commits

Sechs Stueck, in Abhaengigkeitsreihenfolge: die Versionsquelle steht vor dem Skript, das sie liest, die Doku vor der Pruefung, die ihre URLs kontrolliert. Jeder Commit ist fuer sich lauffaehig.

1. Versionsquelle fuer Releases in CHANGELOG.md festlegen
2. Packaging-Skript fuer den Skill-Payload ergaenzen
3. Paketpruefung als eigenes Skript ergaenzen
4. Release-Workflow fuer Tags v* ergaenzen
5. Installationsweg ueber das Release-Artefakt dokumentieren
6. Paket und Versionsangaben in der CI pruefen

### Lokal nachfahren

```bash
python scripts/check-references.py
python scripts/check-frontmatter.py
python scripts/check-checklists.py
python scripts/check-docs-numbers.py
python scripts/check-version.py
python scripts/package-skill.py dist/specforge-skill.zip
python scripts/check-package.py dist/specforge-skill.zip
```

Alle sieben mit exit 0, im frisch geklonten Branch geprueft. Die vier Schritte aus Welle 3 sind unveraendert gruen.

### Nach dem Merge

```bash
git tag v3.2.0 <merge-sha>
git push origin v3.2.0
```

Der Workflow "Release" baut, prueft und haengt `specforge-skill.zip` an. Danach greift `releases/latest/download/specforge-skill.zip`, also die URL, die README und Landingpage bereits nennen. Zwei Dinge, die nicht offensichtlich sind: der Release-Text bleibt leer, die vorbereiteten Notes muessen eingefuegt werden, und `draft: false` heisst, dass das Release oeffentlich ist, sobald der Job durch ist. Wer erst schauen will, setzt vorher `draft: true` im Workflow.

Passt der Tag nicht zur Versionsquelle, bricht der Lauf im ersten Schritt ab und es entsteht kein Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk


---
**Gestapelt.** Dieser PR sitzt auf `ci/welle-3`. GitHub haengt ihn automatisch auf `main` um, sobald der darunterliegende PR gemergt ist. Vorher zeigt der Diff nur die Welle-3-Aenderungen, das ist so gewollt.

Teil von Welle 4 des Haerteplans: Release und Packaging. Jede Aenderung wurde von einem zweiten Durchgang abgenommen, der das Artefakt selbst gebaut, entpackt und den Installationsweg durchgegangen ist.
