### PR TITLE
Wegwerf: Nachweis des Branch-Schutzes

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,3 +422,5 @@ Issues und Pull Requests willkommen. Insbesondere:
 | MaRisk | Finanzsektor (DE) | Offen | — |
 | PCI-DSS 4.0 | Zahlungsverkehr | Offen | — |
 | EnWG / IT-Sicherheitskatalog | Energiesektor | Offen | — |
+
+<!-- Wegwerf-Zeile fuer den Schutz-Nachweis -->


### PR DESCRIPTION
Belegt, dass ein veralteter Branch gesperrt wird. Wird sofort geschlossen.