### PR TITLE
Sicherheitshaerte und fachliche Differenzierung

### DIFF
--- a/.github/actions/specforge-check/action.yml
+++ b/.github/actions/specforge-check/action.yml
@@ -1,0 +1,35 @@
+name: SpecForge Check
+description: Prueft eine spec.md gegen die strukturellen Regeln des SpecForge-Skills.
+
+inputs:
+  pfad:
+    description: spec.md oder Verzeichnis mit spec.md und optionaler tasks.md
+    required: true
+  nach-clarify:
+    description: Offene [Annahme:]- und [Offen:]-Marker beanstanden (true/false)
+    required: false
+    default: 'false'
+  risiko-akzeptanz:
+    description: Datei mit CONDITIONAL-Akzeptanz-Protokollen
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Python bereitstellen
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: specforge check ausfuehren
+      shell: bash
+      env:
+        PFAD: ${{ inputs.pfad }}
+        NACH_CLARIFY: ${{ inputs.nach-clarify }}
+        AKZEPTANZ: ${{ inputs.risiko-akzeptanz }}
+      run: |
+        args=("$PFAD")
+        if [ "$NACH_CLARIFY" = "true" ]; then args+=("--nach-clarify"); fi
+        if [ -n "$AKZEPTANZ" ]; then args+=("--risiko-akzeptanz" "$AKZEPTANZ"); fi
+        python "${{ github.action_path }}/../../../cli/specforge" check "${args[@]}"

--- a/.github/actions/specforge-check/action.yml
+++ b/.github/actions/specforge-check/action.yml
@@ -10,7 +10,10 @@ inputs:
     required: false
     default: 'false'
   risiko-akzeptanz:
-    description: Datei mit CONDITIONAL-Akzeptanz-Protokollen
+    description: >-
+      Datei mit Bloecken nach dem CONDITIONAL-Akzeptanz-Protokoll. Ein Block
+      hebt einen F3-Befund nur auf, wenn alle Pflichtfelder ausgefuellt sind
+      und die Frist nicht abgelaufen ist.
     required: false
     default: ''
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Checklisten und Manifeste pruefen
         run: python scripts/check-checklists.py
 
+      - name: Schweregrad-Dialekt pruefen
+        run: python scripts/check-severity-dialect.py
+
       - name: Zahlenangaben in README und Landingpage pruefen
         run: python scripts/check-docs-numbers.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Linter gegen die Fixtures fahren
         run: python scripts/check-linter-fixtures.py
 
+      - name: Golden Specs pruefen
+        run: python evals/run_static.py
+
       - name: Release-Artefakt bauen
         run: python scripts/package-skill.py dist/specforge-skill.zip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Versionsangaben und Artefaktname pruefen
         run: python scripts/check-version.py
 
+      - name: Linter-Tests ausfuehren
+        run: python -m unittest discover -s tests -v
+
+      - name: Linter gegen die Fixtures fahren
+        run: python scripts/check-linter-fixtures.py
+
       - name: Release-Artefakt bauen
         run: python scripts/package-skill.py dist/specforge-skill.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Thumbs.db
 .idea/
 .vscode/
 dist/
+__pycache__/
+*.pyc

--- a/CONTRIBUTING-CHECKLISTS.md
+++ b/CONTRIBUTING-CHECKLISTS.md
@@ -152,13 +152,26 @@ Schritt 4 bleibt Handarbeit in der Session.
 - [ ] Mindestens 1 NFR-Lücke korrekt erkannt und mit F-Stufe markiert?
 - [ ] Perspektive-Abfrage funktioniert (wenn Pflicht-Abfrage definiert)?
 - [ ] Extension wird bei Trigger-Begriff automatisch geladen?
-- [ ] Mindestens zwei Golden-Fälle unter `evals/golden/` abgelegt: derselbe fehlende Prüfpunkt
-      einmal aus der strengsten und einmal aus der mildesten Perspektive, je mit `expected.json`?
+- [ ] Mindestens zwei Golden-Fälle unter `evals/golden/` abgelegt, und zwar als Paar mit **einer**
+      Variablen: identische `spec.md` mit demselben `[NFR-Lücke F{n}: ...]`-Marker, zwei
+      `specforge.json`, die sich nur in der Perspektive unterscheiden, je mit `expected.json`?
+- [ ] Erzeugt genau eine der beiden Perspektiven den Befund `nfr_severity`, die andere nicht?
 - [ ] `python3 evals/run_static.py` läuft grün?
 
-Der zweite Punkt ist der eigentliche Beleg dafür, dass die F-Stufen-Zuordnung des Manifests
-funktioniert. Eine Extension, deren Perspektiven-Spalten nie unterschiedliche Ergebnisse
-erzeugen, braucht keine Perspektiven.
+Die beiden letzten Punkte sind der Beleg dafür, dass die F-Stufen-Zuordnung des Manifests wirkt.
+Ein Paar, das Perspektive und Marker-Wert zugleich variiert, belegt ihn nicht: die F-Stufe der
+Lücke stammt dann aus dem Marker, und der Unterschied wäre auch ohne Perspektiven-Tabelle da.
+Eine Extension, deren Perspektiven-Spalten nie unterschiedliche Ergebnisse erzeugen, braucht
+keine Perspektiven.
+
+Was der Linter dabei prüft, ist eng: er vergleicht die F-Stufe, die der Autor in den Marker
+geschrieben hat, mit der Tabelle des Manifests. Er leitet keine Stufe aus der Perspektive ab, und
+eine Anforderung, die in der Spec gar nicht als fehlend markiert ist, sieht er nicht. Der
+NFR-Scan gegen die Checkliste bleibt Sache der Session; die Golden-Fälle prüfen die
+Einstufung, nicht die Vollständigkeit. Das Referenzpaar sind
+[`evals/golden/03-dora-regulated-ohne-irm01`](evals/golden/03-dora-regulated-ohne-irm01) und
+[`06-dora-falsche-f-stufe`](evals/golden/06-dora-falsche-f-stufe), die Grenze hält
+[`08-dora-luecke-undokumentiert`](evals/golden/08-dora-luecke-undokumentiert) fest.
 
 ---
 

--- a/CONTRIBUTING-CHECKLISTS.md
+++ b/CONTRIBUTING-CHECKLISTS.md
@@ -146,12 +146,19 @@ Schritt 4 bleibt Handarbeit in der Session.
 - [ ] Trigger-Begriffe sind spezifisch genug (keine generischen Begriffe wie "Sicherheit")?
 - [ ] Perspektiven-Mapping stimmt mit Checkliste überein?
 
-### Schritt 4: Smoke-Test
+### Schritt 4: Smoke-Test und Golden-Fälle
 
 - [ ] Modus 5 (Checklist) mit der neuen Extension gegen eine Minimal-Spec ausführen
 - [ ] Mindestens 1 NFR-Lücke korrekt erkannt und mit F-Stufe markiert?
 - [ ] Perspektive-Abfrage funktioniert (wenn Pflicht-Abfrage definiert)?
 - [ ] Extension wird bei Trigger-Begriff automatisch geladen?
+- [ ] Mindestens zwei Golden-Fälle unter `evals/golden/` abgelegt: derselbe fehlende Prüfpunkt
+      einmal aus der strengsten und einmal aus der mildesten Perspektive, je mit `expected.json`?
+- [ ] `python3 evals/run_static.py` läuft grün?
+
+Der zweite Punkt ist der eigentliche Beleg dafür, dass die F-Stufen-Zuordnung des Manifests
+funktioniert. Eine Extension, deren Perspektiven-Spalten nie unterschiedliche Ergebnisse
+erzeugen, braucht keine Perspektiven.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,11 @@ Python 3.8 oder neuer und sonst nichts: keine Installation, keine Abhängigkeit.
 python3 cli/specforge check specs/mein-feature/spec.md
 ```
 
-Liegt eine `tasks.md` neben der Spec, prüft der Linter zusätzlich die Traceability. Eine
+Liegt eine `tasks.md` neben der Spec, prüft der Linter zusätzlich die Traceability. Fehlt sie,
+läuft AP-07 nicht, und das steht in der Ausgabe: Gate G4 erscheint mit `SKIP` und nennt die beiden
+Prüfpunkte, die niemand angesehen hat; im JSON stehen sie unter `skipped_checks`. Am Exit-Code
+ändert das nichts, denn eine Spezifikation vor der Plan-Phase hat legitim noch keine `tasks.md`.
+Eine gelöschte oder falsch abgelegte Datei soll aber nicht wie ein bestandener Lauf aussehen. Eine
 `specforge.json` wird ab der Spec aufwärts gesucht und ausgewertet; `checks_config` überschreibt
 die Default-F-Stufen, perspektivenabhängig wie in der Session.
 

--- a/README.md
+++ b/README.md
@@ -405,6 +405,11 @@ Liegt eine `tasks.md` neben der Spec, prüft der Linter zusätzlich die Traceabi
 `specforge.json` wird ab der Spec aufwärts gesucht und ausgewertet; `checks_config` überschreibt
 die Default-F-Stufen, perspektivenabhängig wie in der Session.
 
+Das Feld `extensions` nennt die Pakete unter `references/custom/`, die gelten sollen. Die
+Schreibweise des Namens spielt keine Rolle (`@dora`, `@DORA`, `dora`), ein unbekannter Name ist ein
+Aufrufproblem mit Exit 3 statt einer stillschweigend übergangenen Prüfung. Fehlt das Feld, gelten
+alle vorhandenen Pakete; `[]` heißt ausdrücklich: keine Extension.
+
 | Prüfpunkt | F-Stufe | Herkunft |
 |-----------|---------|----------|
 | Keine Story im erkannten Format (leere oder formatfremde Datei) | F4 | [docs/spec-format.md](docs/spec-format.md) |

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Die 10 Fachmodule folgen weitgehend derselben Struktur. Wo eine Sektion fehlt od
 SpecForge ist Prompt-Text, kein Programm. Daraus folgen Grenzen, die keine Version wegräumt:
 
 - **Die CI prüft den Skill, nicht die Ergebnisse.** Der Workflow in `.github/workflows/ci.yml` hält Referenzpfade, Frontmatter, Checklisten, Zahlen- und Versionsangaben konsistent und baut das Release-Paket bei jedem Lauf, damit ein kaputtes Paket vor dem Tag auffällt. Ob eine damit erzeugte Spezifikation fachlich taugt, beurteilt weiterhin ein Mensch.
-- **Enforcement wirkt nur in der Session.** Phase Gates, F-Stufen und Anti-Pattern-Erkennung greifen, solange Claude den Skill geladen hat. Es gibt keinen Linter, der eine fertige `spec.md` außerhalb der Session prüft, und keinen Exit-Code für eine Pipeline.
+- **Der Linter prüft Struktur, nicht Bedeutung.** `specforge check` erkennt fehlende EARS-Pattern, zu wenige Gherkin-Szenarien, Begriffe aus der Blocklist und Traceability-Lücken. Ob die EARS-Formulierung inhaltlich zum Pattern passt, ob ein NFR-Zielwert realistisch ist und ob die STRIDE-Bewertung zu Ende gedacht wurde, entscheidet weiterhin die Session oder ein Mensch. Der Linter meldet solche Punkte nicht als bestanden, sondern gar nicht.
 - **F-Stufen sind Konvention, nicht Typprüfung.** Seit Version 3.2 sprechen alle Module, Checklisten und Templates F0 bis F5; `scripts/check-severity-dialect.py` hält das in der CI fest. Ob Claude im Einzelfall die richtige Stufe vergibt, prüft das Skript nicht — es prüft nur, dass keine zweite Skala danebensteht.
 - **Keine Rechtsberatung.** Die KRITIS-, DORA- und BAIT-Checklisten sind Arbeitshilfen mit Verweis auf die Rechtsquelle. Sie ersetzen keine aufsichtsrechtliche Prüfung. `@bait` ist ausdrücklich ein Stub.
 - **Das Paket ist ein Archiv aus Markdown.** Es installiert nichts und aktualisiert sich nicht. Ein kopierter Ordner erfährt nicht, dass es ein neueres Release gibt; der Abgleich läuft über die `VERSION` im Paket gegen die Releases im Repository.
@@ -391,12 +391,49 @@ Offen, in dieser Reihenfolge:
 
 ---
 
+## `specforge check` — Enforcement außerhalb der Session
+
+Die Phase Gates greifen, solange Claude den Skill geladen hat. Für alles danach — Pull Request,
+Pipeline, Pre-Commit-Hook — liegt derselbe Regelsatz als Linter im Repo. Er braucht Python 3.8
+oder neuer und sonst nichts: keine Installation, keine Abhängigkeit.
+
+```bash
+python3 cli/specforge check specs/mein-feature/spec.md
+```
+
+Liegt eine `tasks.md` neben der Spec, prüft der Linter zusätzlich die Traceability. Eine
+`specforge.json` wird ab der Spec aufwärts gesucht und ausgewertet; `checks_config` überschreibt
+die Default-F-Stufen, perspektivenabhängig wie in der Session.
+
+| Prüfpunkt | F-Stufe | Herkunft |
+|-----------|---------|----------|
+| EARS-Pattern fehlt oder ist unbekannt | F4 | Gate G1 |
+| Weniger als 2 Gherkin-Szenarien je Story | F4 | Gate G1 |
+| Begriff aus der AP-04-Blocklist | F4 | Anti-Pattern AP-04 |
+| SOPHIST-Trigger (`ggf.`, `zeitnah`, `etc.`) | F3 | Anti-Pattern AP-08 |
+| Offene `[Annahme:]`- oder `[Offen:]`-Marker (nur mit `--nach-clarify`) | F3 | SKILL.md, globale Regel 11 |
+| Task ohne Story-Referenz, Story ohne Task | F3 | Anti-Pattern AP-07 |
+| ID folgt nicht `SF-{Präfix}-{NNN}` | F1 | Modus 1 und 7 |
+| Doppelt vergebene Story-ID | F4 | Nachverfolgbarkeit |
+
+Exit-Codes: `0` sauber, `1` mindestens ein F4-Befund, `2` ein F3-Befund ohne dokumentierte
+Risiko-Akzeptanz, `3` Aufrufproblem. Eine Akzeptanz nach dem CONDITIONAL-Protokoll wird mit
+`--risiko-akzeptanz datei.md` übergeben und hebt Exit 2 auf.
+
+Das gelesene Format ist in [docs/spec-format.md](docs/spec-format.md) beschrieben. Für fremde
+Repositories liegt eine Composite Action unter `.github/actions/specforge-check/`, ein
+Beispiel-Workflow in [docs/ci-example.yml](docs/ci-example.yml).
+
+---
+
 ## Weiterführende Dokumente
 
 | Dokument | Inhalt |
 |----------|--------|
 | [docs/skill-als-blaupause.md](docs/skill-als-blaupause.md) | SpecForge als Muster für eigene Claude-Skills: Frontmatter, Modi, Output-Templates, Qualitätsregeln |
 | [docs/quellen-und-einfluesse.md](docs/quellen-und-einfluesse.md) | Herkunft der Methoden: Spec Kit, EARS, Gherkin, STRIDE, Cynefin und die übrigen |
+| [docs/spec-format.md](docs/spec-format.md) | Das maschinenlesbare Format der `spec.md`: Story-Kopf, Pattern-Feld, Scenario-Blöcke, Marker |
+| [docs/f-stufen-entscheidung.md](docs/f-stufen-entscheidung.md) | Warum F0 bis F5 der einzige Schweregrad-Dialekt ist und welcher Prüfpunkt sich dabei verschoben hat |
 | [CONTRIBUTING-CHECKLISTS.md](CONTRIBUTING-CHECKLISTS.md) | Schema, Validierung und Kandidatenliste für eigene Regulierungs-Checklisten |
 
 ---

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Neu in v3: Brownfield-vs-Greenfield-Erkennung, Explore-Phase mit parallelen Arch
 "Prüfe die Konsistenz meiner Artefakte."
 ```
 
-5-Dimensionen-Check: Spec↔Plan, Plan↔Tasks, Spec↔Tasks, GP-Compliance, Security/Compliance. Re-Analyze-Loop (max. 5 Iterationen) bis keine Blocker mehr offen sind.
+5-Dimensionen-Check: Spec↔Plan, Plan↔Tasks, Spec↔Tasks, GP-Compliance, Security/Compliance. Re-Analyze-Loop (max. 5 Iterationen) bis kein F4-Befund mehr offen ist.
 
 ### Modus 5: Checklist — Quality Gates
 

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ die Default-F-Stufen, perspektivenabhängig wie in der Session.
 
 | Prüfpunkt | F-Stufe | Herkunft |
 |-----------|---------|----------|
+| Keine Story im erkannten Format (leere oder formatfremde Datei) | F4 | [docs/spec-format.md](docs/spec-format.md) |
 | EARS-Pattern fehlt oder ist unbekannt | F4 | Gate G1 |
 | Weniger als 2 Gherkin-Szenarien je Story | F4 | Gate G1 |
 | Begriff aus der AP-04-Blocklist | F4 | Anti-Pattern AP-04 |
@@ -427,7 +428,7 @@ nächsten Release über ein Tag erreichbar; im aktuellen Release `v3.2.0` gibt e
 
 ### Golden Specs
 
-Unter `evals/golden/` liegen sechs vollständige Spezifikationen mit ihrem erwarteten Ergebnis.
+Unter `evals/golden/` liegen sieben vollständige Spezifikationen mit ihrem erwarteten Ergebnis.
 Sie sind zugleich die ersten echten Specs im Repo, denn bis dahin gab es nur Templates, und der
 Regressionstest für den Linter:
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,22 @@ Das gelesene Format ist in [docs/spec-format.md](docs/spec-format.md) beschriebe
 Repositories liegt eine Composite Action unter `.github/actions/specforge-check/`, ein
 Beispiel-Workflow in [docs/ci-example.yml](docs/ci-example.yml).
 
+### Golden Specs
+
+Unter `evals/golden/` liegen sechs vollständige Spezifikationen mit ihrem erwarteten Ergebnis.
+Sie sind die ersten echten Specs im Repo — bis dahin gab es nur Templates — und zugleich der
+Regressionstest für den Linter:
+
+```bash
+python3 evals/run_static.py
+```
+
+Das Paar aus Fall 03 und 04 zeigt, wozu die F-Stufen da sind: dieselbe fehlende
+DORA-Anforderung ergibt für ein Finanzunternehmen F4 und blockiert, für ein Beratungsprojekt F2
+und erzeugt einen Pflicht-Task vor Go-Live. Das frühere, dreistufige Vokabular konnte diesen
+Unterschied nicht abbilden; die Umstellung ist in
+[docs/f-stufen-entscheidung.md](docs/f-stufen-entscheidung.md) begründet. Details in [evals/README.md](evals/README.md).
+
 ---
 
 ## Weiterführende Dokumente

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ nächsten Release über ein Tag erreichbar; im aktuellen Release `v3.2.0` gibt e
 
 ### Golden Specs
 
-Unter `evals/golden/` liegen sieben vollständige Spezifikationen mit ihrem erwarteten Ergebnis.
+Unter `evals/golden/` liegen acht vollständige Spezifikationen mit ihrem erwarteten Ergebnis.
 Sie sind zugleich die ersten echten Specs im Repo, denn bis dahin gab es nur Templates, und der
 Regressionstest für den Linter:
 
@@ -445,11 +445,19 @@ Regressionstest für den Linter:
 python3 evals/run_static.py
 ```
 
-Das Paar aus Fall 03 und 04 zeigt, wozu die F-Stufen da sind: dieselbe fehlende
-DORA-Anforderung ergibt für ein Finanzunternehmen F4 und blockiert, für ein Beratungsprojekt F2
-und erzeugt einen Pflicht-Task vor Go-Live. Das frühere, dreistufige Vokabular konnte diesen
-Unterschied nicht abbilden; die Umstellung ist in
-[docs/f-stufen-entscheidung.md](docs/f-stufen-entscheidung.md) begründet. Details in [evals/README.md](evals/README.md).
+Das Paar aus Fall 03 und 06 zeigt, was die Perspektive im Linter bewirkt: identische `spec.md`,
+zwei `specforge.json`, die sich nur in der Perspektive unterscheiden. Die als F4 markierte
+DORA-Lücke ist für ein Finanzunternehmen richtig eingestuft und bleibt ein einzelner Befund; für
+ein Beratungsprojekt sieht `@dora` F2 vor, und die zu harte Einstufung kommt als zweiter Befund
+`nfr_severity` dazu. Fall 04 zeigt die dazu passende mildere Einstufung, die das Gate mit einem
+Pflicht-Task vor Go-Live passiert. Das frühere, dreistufige Vokabular konnte diesen Unterschied
+nicht abbilden; die Umstellung ist in
+[docs/f-stufen-entscheidung.md](docs/f-stufen-entscheidung.md) begründet.
+
+Was der Linter dabei prüft, ist die Selbsteinstufung des Autors gegen das Manifest der Extension.
+Die F-Stufe einer Lücke liest er aus dem Marker `[NFR-Lücke F{n}: ...]`; eine Anforderung, die
+niemand als fehlend markiert hat, bemerkt er nicht. Fall 08 hält diese Grenze fest. Details in
+[evals/README.md](evals/README.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ SpecForge wird:
 "Kläre die offenen Fragen in meiner Spec."
 ```
 
-SpecForge scannt die spec.md nach Lücken, vagen Begriffen und unbestätigten Annahmen. Fragen werden mit Schweregrad (BLOCKER / MAJOR / MINOR) priorisiert.
+SpecForge scannt die spec.md nach Lücken, vagen Begriffen und unbestätigten Annahmen. Fragen werden mit F-Stufe (F4 bis F1) priorisiert.
 
 ### Modus 3: Plan & Tasks — Von Spec zum Backlog
 
@@ -373,7 +373,7 @@ SpecForge ist Prompt-Text, kein Programm. Daraus folgen Grenzen, die keine Versi
 
 - **Die CI prüft den Skill, nicht die Ergebnisse.** Der Workflow in `.github/workflows/ci.yml` hält Referenzpfade, Frontmatter, Checklisten, Zahlen- und Versionsangaben konsistent und baut das Release-Paket bei jedem Lauf, damit ein kaputtes Paket vor dem Tag auffällt. Ob eine damit erzeugte Spezifikation fachlich taugt, beurteilt weiterhin ein Mensch.
 - **Enforcement wirkt nur in der Session.** Phase Gates, F-Stufen und Anti-Pattern-Erkennung greifen, solange Claude den Skill geladen hat. Es gibt keinen Linter, der eine fertige `spec.md` außerhalb der Session prüft, und keinen Exit-Code für eine Pipeline.
-- **Zwei Schweregrad-Dialekte nebeneinander.** `enforcement-engine.md` und Modus 10 arbeiten mit F-Stufen, mehrere ältere Module noch mit BLOCKER/MAJOR/MINOR. Das Mapping am Ende von `references/checklists/kritis-nfr.md` deckt drei der sechs Stufen ab. Solange das so ist, hängt die gemeldete Stufe davon ab, welches Modul antwortet.
+- **F-Stufen sind Konvention, nicht Typprüfung.** Seit Version 3.2 sprechen alle Module, Checklisten und Templates F0 bis F5; `scripts/check-severity-dialect.py` hält das in der CI fest. Ob Claude im Einzelfall die richtige Stufe vergibt, prüft das Skript nicht — es prüft nur, dass keine zweite Skala danebensteht.
 - **Keine Rechtsberatung.** Die KRITIS-, DORA- und BAIT-Checklisten sind Arbeitshilfen mit Verweis auf die Rechtsquelle. Sie ersetzen keine aufsichtsrechtliche Prüfung. `@bait` ist ausdrücklich ein Stub.
 - **Das Paket ist ein Archiv aus Markdown.** Es installiert nichts und aktualisiert sich nicht. Ein kopierter Ordner erfährt nicht, dass es ein neueres Release gibt; der Abgleich läuft über die `VERSION` im Paket gegen die Releases im Repository.
 - **Deutsch als Arbeitssprache.** Der Skill antwortet englisch auf englische Eingaben, die Referenzdateien und Checklisten bleiben deutsch.
@@ -384,12 +384,10 @@ SpecForge ist Prompt-Text, kein Programm. Daraus folgen Grenzen, die keine Versi
 
 Offen, in dieser Reihenfolge:
 
-1. **Schweregrade vereinheitlichen:** BLOCKER/MAJOR/MINOR in den Modulen auf F-Stufen umstellen, damit derselbe Mangel in jedem Modus dieselbe Stufe bekommt.
-2. **Beispiel-Spezifikationen ins Repo:** hier liegen nur Templates und Eingabe-Prompts, keine fertige Spec, an der sich ein Ergebnis messen ließe.
-3. **`@bait` vervollständigen:** vom Stub auf die Kapitel der BaFin-Rundschreiben 10/2017 (BA) und 10/2021 (BA).
-4. **Weitere Regulierungen:** MaRisk, PCI-DSS 4.0, EnWG/IT-Sicherheitskatalog. Priorisierung in [CONTRIBUTING-CHECKLISTS.md](CONTRIBUTING-CHECKLISTS.md), Abschnitt 5.
-5. **Erstes Release veröffentlichen:** Packaging-Skript, Paketprüfung und Release-Workflow liegen im Repo, der Tag `v3.2.0` ist noch nicht gesetzt. Bis dahin läuft `releases/latest/download/` ins Leere.
-6. **Englische Fassung** des Payloads.
+1. **`@bait` vervollständigen:** vom Stub auf die Kapitel der BaFin-Rundschreiben 10/2017 (BA) und 10/2021 (BA).
+2. **Weitere Regulierungen:** MaRisk, PCI-DSS 4.0, EnWG/IT-Sicherheitskatalog. Priorisierung in [CONTRIBUTING-CHECKLISTS.md](CONTRIBUTING-CHECKLISTS.md), Abschnitt 5.
+3. **Erstes Release veröffentlichen:** Packaging-Skript, Paketprüfung und Release-Workflow liegen im Repo, der Tag `v3.2.0` ist noch nicht gesetzt. Bis dahin läuft `releases/latest/download/` ins Leere.
+4. **Englische Fassung** des Payloads.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,15 @@ Exit-Codes: `0` sauber, `1` mindestens ein F4-Befund, `2` ein F3-Befund ohne dok
 Risiko-Akzeptanz, `3` Aufrufproblem. Eine Akzeptanz nach dem CONDITIONAL-Protokoll wird mit
 `--risiko-akzeptanz datei.md` übergeben und hebt Exit 2 auf.
 
+Der Linter liest die Datei als Protokoll, nicht als Fließtext. Ein Block hebt einen F3-Befund nur
+auf, wenn seine Überschrift `## Risiko-Akzeptanz: <Betreff>` den Betreff des Befunds als eigenes
+Wort nennt, alle Pflichtfelder aus
+[enforcement-engine.md I.5](references/enforcement/enforcement-engine.md) ausgefüllt sind (Gate,
+Prüfpunkt, F-Stufe, Risiko, Akzeptiert durch, Kompensation, Frist, Datum), die F-Stufe zum Befund
+passt und die Frist als Datum `YYYY-MM-DD` in der Zukunft liegt. Was daran fehlt, steht als eigene
+Zeile unter `Risiko-Akzeptanz:` in der Ausgabe. Eine Datei, die den Prüfpunkt nur erwähnt, ist
+keine Freigabe.
+
 Das gelesene Format ist in [docs/spec-format.md](docs/spec-format.md) beschrieben. Für fremde
 Repositories liegt eine Composite Action unter `.github/actions/specforge-check/`, ein
 Beispiel-Workflow in [docs/ci-example.yml](docs/ci-example.yml). Die Action ist erst ab dem

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ SpecForge ist Prompt-Text, kein Programm. Daraus folgen Grenzen, die keine Versi
 
 - **Die CI prüft den Skill, nicht die Ergebnisse.** Der Workflow in `.github/workflows/ci.yml` hält Referenzpfade, Frontmatter, Checklisten, Zahlen- und Versionsangaben konsistent und baut das Release-Paket bei jedem Lauf, damit ein kaputtes Paket vor dem Tag auffällt. Ob eine damit erzeugte Spezifikation fachlich taugt, beurteilt weiterhin ein Mensch.
 - **Der Linter prüft Struktur, nicht Bedeutung.** `specforge check` erkennt fehlende EARS-Pattern, zu wenige Gherkin-Szenarien, Begriffe aus der Blocklist und Traceability-Lücken. Ob die EARS-Formulierung inhaltlich zum Pattern passt, ob ein NFR-Zielwert realistisch ist und ob die STRIDE-Bewertung zu Ende gedacht wurde, entscheidet weiterhin die Session oder ein Mensch. Der Linter meldet solche Punkte nicht als bestanden, sondern gar nicht.
-- **F-Stufen sind Konvention, nicht Typprüfung.** Seit Version 3.2 sprechen alle Module, Checklisten und Templates F0 bis F5; `scripts/check-severity-dialect.py` hält das in der CI fest. Ob Claude im Einzelfall die richtige Stufe vergibt, prüft das Skript nicht — es prüft nur, dass keine zweite Skala danebensteht.
+- **F-Stufen sind Konvention, nicht Typprüfung.** Alle Module, Checklisten und Templates sprechen F0 bis F5; `scripts/check-severity-dialect.py` hält das in der CI fest. Ob Claude im Einzelfall die richtige Stufe vergibt, prüft das Skript nicht. Es prüft nur, dass keine zweite Skala danebensteht.
 - **Keine Rechtsberatung.** Die KRITIS-, DORA- und BAIT-Checklisten sind Arbeitshilfen mit Verweis auf die Rechtsquelle. Sie ersetzen keine aufsichtsrechtliche Prüfung. `@bait` ist ausdrücklich ein Stub.
 - **Das Paket ist ein Archiv aus Markdown.** Es installiert nichts und aktualisiert sich nicht. Ein kopierter Ordner erfährt nicht, dass es ein neueres Release gibt; der Abgleich läuft über die `VERSION` im Paket gegen die Releases im Repository.
 - **Deutsch als Arbeitssprache.** Der Skill antwortet englisch auf englische Eingaben, die Referenzdateien und Checklisten bleiben deutsch.
@@ -386,16 +386,16 @@ Offen, in dieser Reihenfolge:
 
 1. **`@bait` vervollständigen:** vom Stub auf die Kapitel der BaFin-Rundschreiben 10/2017 (BA) und 10/2021 (BA).
 2. **Weitere Regulierungen:** MaRisk, PCI-DSS 4.0, EnWG/IT-Sicherheitskatalog. Priorisierung in [CONTRIBUTING-CHECKLISTS.md](CONTRIBUTING-CHECKLISTS.md), Abschnitt 5.
-3. **Erstes Release veröffentlichen:** Packaging-Skript, Paketprüfung und Release-Workflow liegen im Repo, der Tag `v3.2.0` ist noch nicht gesetzt. Bis dahin läuft `releases/latest/download/` ins Leere.
+3. **Composite Action ausliefern:** `.github/actions/specforge-check/` liegt im Repo, ist aber erst über ein Tag ab dem nächsten Release als `uses:` erreichbar. Bis dahin ruft ein fremdes Repository den Linter über einen eigenen Checkout auf.
 4. **Englische Fassung** des Payloads.
 
 ---
 
-## `specforge check` — Enforcement außerhalb der Session
+## `specforge check`: Enforcement außerhalb der Session
 
-Die Phase Gates greifen, solange Claude den Skill geladen hat. Für alles danach — Pull Request,
-Pipeline, Pre-Commit-Hook — liegt derselbe Regelsatz als Linter im Repo. Er braucht Python 3.8
-oder neuer und sonst nichts: keine Installation, keine Abhängigkeit.
+Die Phase Gates greifen, solange Claude den Skill geladen hat. Für alles danach, also Pull
+Request, Pipeline und Pre-Commit-Hook, liegt derselbe Regelsatz als Linter im Repo. Er braucht
+Python 3.8 oder neuer und sonst nichts: keine Installation, keine Abhängigkeit.
 
 ```bash
 python3 cli/specforge check specs/mein-feature/spec.md
@@ -422,12 +422,13 @@ Risiko-Akzeptanz, `3` Aufrufproblem. Eine Akzeptanz nach dem CONDITIONAL-Protoko
 
 Das gelesene Format ist in [docs/spec-format.md](docs/spec-format.md) beschrieben. Für fremde
 Repositories liegt eine Composite Action unter `.github/actions/specforge-check/`, ein
-Beispiel-Workflow in [docs/ci-example.yml](docs/ci-example.yml).
+Beispiel-Workflow in [docs/ci-example.yml](docs/ci-example.yml). Die Action ist erst ab dem
+nächsten Release über ein Tag erreichbar; im aktuellen Release `v3.2.0` gibt es sie noch nicht.
 
 ### Golden Specs
 
 Unter `evals/golden/` liegen sechs vollständige Spezifikationen mit ihrem erwarteten Ergebnis.
-Sie sind die ersten echten Specs im Repo — bis dahin gab es nur Templates — und zugleich der
+Sie sind zugleich die ersten echten Specs im Repo, denn bis dahin gab es nur Templates, und der
 Regressionstest für den Linter:
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -80,12 +80,12 @@ Maschinenlesbare Projektkonfiguration. Wird bei Projekt-Setup (Modus 1) erzeugt.
       }
     }
   },
-  "extensions": ["@custom/*"],
+  "extensions": ["@dora"],
   "audit": true
 }
 ```
 
-**Feld-Erläuterungen:** `active_gps` = GP-01 bis GP-10, profilabhängig aktiv. `perspective` = Rolle in der Wertschöpfungskette (freier String, von Extensions definiert; `null` = keine Perspektive). `conventions` = steuert Sprachverhalten und Commit-Konvention. `severity_model` = 6-stufiges Schweregrad-System (F0–F5) mit Gate-Mapping; fehlt dieses Feld, wird die Konfiguration beim Einlesen einmalig über das Legacy-Mapping übersetzt (`required: true` → F4, `required: false` → F1, siehe enforcement-engine.md). Danach gilt auch dort ausschließlich das F-Stufen-Vokabular. F-Stufen sind der einzige Dialekt in Modulprosa, Checklisten, Templates und Gate-Ausgaben. `checks_config` = Beispiel für G1 — `severity` kann ein String (gilt für alle Perspektiven) oder ein Objekt mit `_default` + perspektivenspezifischen Werten sein. `artifacts_expected` = pro Gate erwartete Artefakte; `["*"]` bei G5 bedeutet: alle Artefakte aller vorherigen Gates müssen vorhanden sein (Vollständigkeitscheck). `audit` = Audit Trail aktivieren (bei KRITIS immer true).
+**Feld-Erläuterungen:** `active_gps` = GP-01 bis GP-10, profilabhängig aktiv. `perspective` = Rolle in der Wertschöpfungskette (freier String, von Extensions definiert; `null` = keine Perspektive). `conventions` = steuert Sprachverhalten und Commit-Konvention. `severity_model` = 6-stufiges Schweregrad-System (F0–F5) mit Gate-Mapping; fehlt dieses Feld, wird die Konfiguration beim Einlesen einmalig über das Legacy-Mapping übersetzt (`required: true` → F4, `required: false` → F1, siehe enforcement-engine.md). Danach gilt auch dort ausschließlich das F-Stufen-Vokabular. F-Stufen sind der einzige Dialekt in Modulprosa, Checklisten, Templates und Gate-Ausgaben. `checks_config` = Beispiel für G1 — `severity` kann ein String (gilt für alle Perspektiven) oder ein Objekt mit `_default` + perspektivenspezifischen Werten sein. `artifacts_expected` = pro Gate erwartete Artefakte; `["*"]` bei G5 bedeutet: alle Artefakte aller vorherigen Gates müssen vorhanden sein (Vollständigkeitscheck). `extensions` = Liste der aktiven Pakete unter `references/custom/`, jeweils der Verzeichnisname wie `@dora`. Groß- und Kleinschreibung und ein fehlendes `@` sind egal, ein unbekannter Name ist ein Fehler und wird nicht stillschweigend übergangen. Fehlt das Feld, gelten alle vorhandenen Pakete; eine leere Liste `[]` heißt ausdrücklich: keine Extension. `audit` = Audit Trail aktivieren (bei KRITIS immer true).
 
 ### Drei Profile — Governance skaliert mit Risiko
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -85,7 +85,7 @@ Maschinenlesbare Projektkonfiguration. Wird bei Projekt-Setup (Modus 1) erzeugt.
 }
 ```
 
-**Feld-Erläuterungen:** `active_gps` = GP-01 bis GP-10, profilabhängig aktiv. `perspective` = Rolle in der Wertschöpfungskette (freier String, von Extensions definiert; `null` = keine Perspektive). `conventions` = steuert Sprachverhalten und Commit-Konvention. `severity_model` = 6-stufiges Schweregrad-System (F0–F5) mit Gate-Mapping; fehlt dieses Feld, wird die Konfiguration beim Einlesen einmalig über das Legacy-Mapping übersetzt (`required: true` → F4, `required: false` → F1, siehe enforcement-engine.md). Danach gilt auch dort ausschließlich das F-Stufen-Vokabular — F-Stufen sind der einzige Dialekt in Modulprosa, Checklisten, Templates und Gate-Ausgaben. `checks_config` = Beispiel für G1 — `severity` kann ein String (gilt für alle Perspektiven) oder ein Objekt mit `_default` + perspektivenspezifischen Werten sein. `artifacts_expected` = pro Gate erwartete Artefakte; `["*"]` bei G5 bedeutet: alle Artefakte aller vorherigen Gates müssen vorhanden sein (Vollständigkeitscheck). `audit` = Audit Trail aktivieren (bei KRITIS immer true).
+**Feld-Erläuterungen:** `active_gps` = GP-01 bis GP-10, profilabhängig aktiv. `perspective` = Rolle in der Wertschöpfungskette (freier String, von Extensions definiert; `null` = keine Perspektive). `conventions` = steuert Sprachverhalten und Commit-Konvention. `severity_model` = 6-stufiges Schweregrad-System (F0–F5) mit Gate-Mapping; fehlt dieses Feld, wird die Konfiguration beim Einlesen einmalig über das Legacy-Mapping übersetzt (`required: true` → F4, `required: false` → F1, siehe enforcement-engine.md). Danach gilt auch dort ausschließlich das F-Stufen-Vokabular. F-Stufen sind der einzige Dialekt in Modulprosa, Checklisten, Templates und Gate-Ausgaben. `checks_config` = Beispiel für G1 — `severity` kann ein String (gilt für alle Perspektiven) oder ein Objekt mit `_default` + perspektivenspezifischen Werten sein. `artifacts_expected` = pro Gate erwartete Artefakte; `["*"]` bei G5 bedeutet: alle Artefakte aller vorherigen Gates müssen vorhanden sein (Vollständigkeitscheck). `audit` = Audit Trail aktivieren (bei KRITIS immer true).
 
 ### Drei Profile — Governance skaliert mit Risiko
 
@@ -406,7 +406,7 @@ Die Reports werden zu einem konsolidierten Analyze-Report zusammengeführt. Bei 
     - **AP-03 Implizite Annahmen** (F3): Fehlende `[Annahme: ...]`-Marker
     - **AP-04 Vage Quantifizierung** (F4): Nicht messbare Anforderungen → siehe Blocklist oben
     - **AP-05 Scope Creep** (F4): Tasks ohne Spec-Referenz (GP-02)
-    - **AP-06 Missing Negative** (F3): Nur Happy Path trotz ≥2 Szenarien, kein Unwanted-Pattern — weniger als 2 Szenarien ist der Gate-Prüfpunkt Gherkin-Minimum (F4)
+    - **AP-06 Missing Negative** (F3): Nur Happy Path trotz ≥2 Szenarien, kein Unwanted-Pattern; weniger als 2 Szenarien ist der Gate-Prüfpunkt Gherkin-Minimum (F4)
     - **AP-07 Orphan Artifact** (F3): Task ohne Story, Story ohne Spec
     - **AP-08 SOPHIST-Verletzung** (F3): Passiv ohne Akteur, Negation statt Positivaussage, optionale Formulierung ohne Bedingung ("ggf.", "evtl."), generische Begriffe ("das System", "der Nutzer"), unvollständige Aufzählung ("etc.", "usw."), implizite Zeitangabe ("zeitnah", "umgehend")
 11. **Offene Punkte** — Wenn bei Story-Erzeugung nicht alle Informationen vorliegen: Story trotzdem erstellen und offene Punkte als `[Offen: ...]`-Marker anhängen. Marker werden bei Clarify aufgelöst. Verbleibende `[Offen: ...]` nach Clarify → F3 im Gate.

--- a/SKILL.md
+++ b/SKILL.md
@@ -85,7 +85,7 @@ Maschinenlesbare Projektkonfiguration. Wird bei Projekt-Setup (Modus 1) erzeugt.
 }
 ```
 
-**Feld-Erläuterungen:** `active_gps` = GP-01 bis GP-10, profilabhängig aktiv. `perspective` = Rolle in der Wertschöpfungskette (freier String, von Extensions definiert; `null` = keine Perspektive). `conventions` = steuert Sprachverhalten und Commit-Konvention. `severity_model` = 6-stufiges Schweregrad-System (F0–F5) mit Gate-Mapping; fehlt dieses Feld, gilt Legacy-Verhalten (`required: true` → F4, `required: false` → F1). `checks_config` = Beispiel für G1 — `severity` kann ein String (gilt für alle Perspektiven) oder ein Objekt mit `_default` + perspektivenspezifischen Werten sein. `artifacts_expected` = pro Gate erwartete Artefakte; `["*"]` bei G5 bedeutet: alle Artefakte aller vorherigen Gates müssen vorhanden sein (Vollständigkeitscheck). `audit` = Audit Trail aktivieren (bei KRITIS immer true).
+**Feld-Erläuterungen:** `active_gps` = GP-01 bis GP-10, profilabhängig aktiv. `perspective` = Rolle in der Wertschöpfungskette (freier String, von Extensions definiert; `null` = keine Perspektive). `conventions` = steuert Sprachverhalten und Commit-Konvention. `severity_model` = 6-stufiges Schweregrad-System (F0–F5) mit Gate-Mapping; fehlt dieses Feld, wird die Konfiguration beim Einlesen einmalig über das Legacy-Mapping übersetzt (`required: true` → F4, `required: false` → F1, siehe enforcement-engine.md). Danach gilt auch dort ausschließlich das F-Stufen-Vokabular — F-Stufen sind der einzige Dialekt in Modulprosa, Checklisten, Templates und Gate-Ausgaben. `checks_config` = Beispiel für G1 — `severity` kann ein String (gilt für alle Perspektiven) oder ein Objekt mit `_default` + perspektivenspezifischen Werten sein. `artifacts_expected` = pro Gate erwartete Artefakte; `["*"]` bei G5 bedeutet: alle Artefakte aller vorherigen Gates müssen vorhanden sein (Vollständigkeitscheck). `audit` = Audit Trail aktivieren (bei KRITIS immer true).
 
 ### Drei Profile — Governance skaliert mit Risiko
 
@@ -393,7 +393,7 @@ Die Reports werden zu einem konsolidierten Analyze-Report zusammengeführt. Bei 
 
 1. **SSOT** — spec.md ist Single Source of Truth (GP-02)
 2. **EARS** — Jede Story hat ein explizit benanntes EARS-Pattern
-3. **Gherkin** — Jede Story hat ≥2 Szenarien (Happy Path + Fehlerfall)
+3. **Gherkin** — Jede Story hat ≥2 Szenarien (Happy Path + Fehlerfall). Unterschreitung ist F4 und blockiert Gate G1.
 4. **Quantifizierung** — Keine vagen Begriffe. Blocklist: "schnell" → "≤200ms p95", "viele" → "≥10.000 concurrent", "skalierbar" → "≥Y req/s", "sicher" → konkretes Verfahren + Standard, "zuverlässig" → "≥99.9% Uptime", "einfach" → "≤N Klicks/Schritte"
 5. **Golden Principles** — Aktive GPs laut Profil bei jedem Output prüfen
 6. **STRIDE** — Scope laut Profil (KRITIS: immer, Standard: SEC-Stories, Startup: optional)
@@ -406,7 +406,7 @@ Die Reports werden zu einem konsolidierten Analyze-Report zusammengeführt. Bei 
     - **AP-03 Implizite Annahmen** (F3): Fehlende `[Annahme: ...]`-Marker
     - **AP-04 Vage Quantifizierung** (F4): Nicht messbare Anforderungen → siehe Blocklist oben
     - **AP-05 Scope Creep** (F4): Tasks ohne Spec-Referenz (GP-02)
-    - **AP-06 Missing Negative** (F3): Nur Happy Path, <2 Gherkin, kein Unwanted-Pattern
+    - **AP-06 Missing Negative** (F3): Nur Happy Path trotz ≥2 Szenarien, kein Unwanted-Pattern — weniger als 2 Szenarien ist der Gate-Prüfpunkt Gherkin-Minimum (F4)
     - **AP-07 Orphan Artifact** (F3): Task ohne Story, Story ohne Spec
     - **AP-08 SOPHIST-Verletzung** (F3): Passiv ohne Akteur, Negation statt Positivaussage, optionale Formulierung ohne Bedingung ("ggf.", "evtl."), generische Begriffe ("das System", "der Nutzer"), unvollständige Aufzählung ("etc.", "usw."), implizite Zeitangabe ("zeitnah", "umgehend")
 11. **Offene Punkte** — Wenn bei Story-Erzeugung nicht alle Informationen vorliegen: Story trotzdem erstellen und offene Punkte als `[Offen: ...]`-Marker anhängen. Marker werden bei Clarify aufgelöst. Verbleibende `[Offen: ...]` nach Clarify → F3 im Gate.

--- a/SKILL.md
+++ b/SKILL.md
@@ -97,7 +97,7 @@ Maschinenlesbare Projektkonfiguration. Wird bei Projekt-Setup (Modus 1) erzeugt.
 | Research | Pflicht bei Tech-Entscheidungen | Empfohlen | Optional |
 | GP-Scope | GP-01–10 alle aktiv | GP-01–08 (konfigurierbar) | GP-02 + GP-07 Minimum |
 | Phase Gates | Strikt, kein Skip ohne Protokoll | Skip mit Einzeiler-Begründung | Soft Gates, Empfehlungen |
-| Analyze | Pflicht, Loop bis Blocker-frei | Empfohlen nach Tasks | Optional |
+| Analyze | Pflicht, Loop bis kein F4 mehr offen ist | Empfohlen nach Tasks | Optional |
 
 **Kein Profil angegeben?** → Resolution-Cascade anwenden (siehe unten). Falls keine Quelle greift → Standard. Explizit nachfragen, wenn regulatorischer Kontext erkennbar ist.
 

--- a/cli/specforge
+++ b/cli/specforge
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Einstiegspunkt fuer den Aufruf 'specforge check <pfad>'.
+
+Bewusst ohne Installation: das Repo ist ein Markdown-Skill, kein
+Python-Projekt, und ein Linter, der erst ein pip install braucht, wird in
+einer fremden Pipeline nicht benutzt. Der Aufruf lautet:
+
+    python3 cli/specforge check specs/mein-feature/spec.md
+
+Aequivalent, wenn cli/ im PYTHONPATH liegt:
+
+    python3 -m specforge_check specs/mein-feature/spec.md
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from specforge_check.__main__ import main  # noqa: E402
+
+USAGE = """Aufruf: specforge <befehl> [optionen]
+
+Befehle:
+  check <pfad>   spec.md oder Verzeichnis gegen die SpecForge-Regeln pruefen
+
+'specforge check --help' zeigt die Optionen."""
+
+
+def run(argv):
+    if len(argv) < 2 or argv[1] in ("-h", "--help", "help"):
+        print(USAGE)
+        return 0 if len(argv) > 1 else 3
+    if argv[1] != "check":
+        sys.stderr.write("FEHLER: unbekannter Befehl %r\n\n" % argv[1])
+        sys.stderr.write(USAGE + "\n")
+        return 3
+    return main(argv[2:])
+
+
+if __name__ == "__main__":
+    sys.exit(run(sys.argv))

--- a/cli/specforge_check/__init__.py
+++ b/cli/specforge_check/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""specforge check — Linter fuer SpecForge-Artefakte.
+"""specforge check: Linter fuer SpecForge-Artefakte.
 
 Der Skill setzt seine Regeln bisher nur in der Claude-Session durch. Dieses
 Paket prueft den strukturell entscheidbaren Teil davon ausserhalb: in einer

--- a/cli/specforge_check/__init__.py
+++ b/cli/specforge_check/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""specforge check — Linter fuer SpecForge-Artefakte.
+
+Der Skill setzt seine Regeln bisher nur in der Claude-Session durch. Dieses
+Paket prueft den strukturell entscheidbaren Teil davon ausserhalb: in einer
+Pipeline, in einem Pre-Commit-Hook, auf der Kommandozeile.
+
+Geprueft wird gegen dieselben F-Stufen, die enforcement-engine.md fuehrt.
+Das Ausgabeformat ist das Gate-Ergebnis-Format aus demselben Dokument.
+"""
+
+VERSION = "3.2"
+
+__all__ = ["VERSION"]

--- a/cli/specforge_check/__main__.py
+++ b/cli/specforge_check/__main__.py
@@ -26,10 +26,10 @@ if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(
         os.path.abspath(__file__))))
     from specforge_check import config as config_mod
-    from specforge_check import report, rules, spec as spec_mod
+    from specforge_check import extensions, report, rules, spec as spec_mod
 else:
     from . import config as config_mod
-    from . import report, rules, spec as spec_mod
+    from . import extensions, report, rules, spec as spec_mod
 
 ACCEPT_BLOCK_RE = re.compile(r"^##\s+Risiko-Akzeptanz\s*:", re.M)
 
@@ -88,6 +88,9 @@ def build_parser():
                              "beanstanden")
     parser.add_argument("--risiko-akzeptanz", dest="acceptance",
                         help="Datei mit CONDITIONAL-Akzeptanz-Protokollen")
+    parser.add_argument("--extensions", dest="extensions",
+                        help="Wurzel mit references/custom/ (sonst dieses "
+                             "Repository)")
     parser.add_argument("--json", dest="as_json", action="store_true",
                         help="Befunde als JSON statt als Gate-Ausgabe")
     return parser
@@ -112,7 +115,12 @@ def main(argv=None):
     document = spec_mod.parse_spec(spec_path)
     tasks = spec_mod.parse_tasks(tasks_path) if tasks_path else None
 
-    findings = rules.run(document, tasks, configuration, args.after_clarify)
+    root = args.extensions or os.path.dirname(os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))))
+    packages = extensions.load(root, configuration.data.get("extensions"))
+
+    findings = rules.run(document, tasks, configuration, args.after_clarify,
+                         packages)
     accepted = accepted_findings(findings, load_acceptance(args.acceptance))
 
     if args.as_json:
@@ -123,6 +131,8 @@ def main(argv=None):
               % (configuration.profile or "nicht gesetzt",
                  configuration.perspective or "nicht gesetzt",
                  config_path or "keine"))
+        print("Extensions: %s"
+              % (", ".join(sorted(packages)) if packages else "keine"))
         if configuration.legacy:
             print("Hinweis: specforge.json ohne severity_model — "
                   "Legacy-Werte werden beim Einlesen einmal uebersetzt.")

--- a/cli/specforge_check/__main__.py
+++ b/cli/specforge_check/__main__.py
@@ -12,7 +12,7 @@ Exit-Codes:
     0  kein F4, kein offener F3
     1  mindestens ein F4-Befund, Gate blockiert
     2  mindestens ein F3-Befund ohne dokumentierte Risiko-Akzeptanz
-    3  Aufrufproblem (Datei fehlt, Datei unlesbar)
+    3  Aufrufproblem (Datei fehlt, Datei unlesbar, unbekannte Extension)
 
 Nur Standardbibliothek.
 """
@@ -97,7 +97,13 @@ def main(argv=None):
 
     root = args.extensions or os.path.dirname(os.path.dirname(
         os.path.dirname(os.path.abspath(__file__))))
-    packages = extensions.load(root, configuration.data.get("extensions"))
+    try:
+        packages = extensions.load(root, configuration.extensions)
+    except extensions.ExtensionFehler as error:
+        sys.stderr.write("FEHLER: %s\n" % error)
+        if config_path:
+            sys.stderr.write("        Angabe steht in %s\n" % config_path)
+        return 3
 
     findings = rules.run(document, tasks, configuration, args.after_clarify,
                          packages)
@@ -113,8 +119,13 @@ def main(argv=None):
               % (configuration.profile or "nicht gesetzt",
                  configuration.perspective or "nicht gesetzt",
                  config_path or "keine"))
-        print("Extensions: %s"
-              % (", ".join(sorted(packages)) if packages else "keine"))
+        if packages:
+            geladen = ", ".join(sorted(packages))
+        elif configuration.extensions == []:
+            geladen = "keine (in specforge.json abgewaehlt)"
+        else:
+            geladen = "keine"
+        print("Extensions: %s" % geladen)
         if configuration.legacy:
             print("Hinweis: specforge.json ohne severity_model, "
                   "Legacy-Werte werden beim Einlesen einmal uebersetzt.")

--- a/cli/specforge_check/__main__.py
+++ b/cli/specforge_check/__main__.py
@@ -10,7 +10,7 @@ tasks.md daneben, wird sie mitgeprueft.
 Exit-Codes:
 
     0  kein F4, kein offener F3
-    1  mindestens ein F4-Befund — Gate blockiert
+    1  mindestens ein F4-Befund, Gate blockiert
     2  mindestens ein F3-Befund ohne dokumentierte Risiko-Akzeptanz
     3  Aufrufproblem (Datei fehlt, Datei unlesbar)
 
@@ -134,7 +134,7 @@ def main(argv=None):
         print("Extensions: %s"
               % (", ".join(sorted(packages)) if packages else "keine"))
         if configuration.legacy:
-            print("Hinweis: specforge.json ohne severity_model — "
+            print("Hinweis: specforge.json ohne severity_model, "
                   "Legacy-Werte werden beim Einlesen einmal uebersetzt.")
         print("")
         for line in report.render(document, findings, tasks, accepted):

--- a/cli/specforge_check/__main__.py
+++ b/cli/specforge_check/__main__.py
@@ -112,7 +112,7 @@ def main(argv=None):
 
     if args.as_json:
         print(report.as_json(document, findings, accepted,
-                             acceptance_messages))
+                             acceptance_messages, tasks))
     else:
         print("specforge check %s" % spec_path)
         print("Profil: %s · Perspektive: %s · Konfiguration: %s"

--- a/cli/specforge_check/__main__.py
+++ b/cli/specforge_check/__main__.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""Kommandozeile: specforge check.
+
+    python -m specforge_check <pfad> [optionen]
+    cli/specforge check <pfad> [optionen]
+
+<pfad> ist eine spec.md oder ein Verzeichnis, das eine enthaelt. Liegt eine
+tasks.md daneben, wird sie mitgeprueft.
+
+Exit-Codes:
+
+    0  kein F4, kein offener F3
+    1  mindestens ein F4-Befund — Gate blockiert
+    2  mindestens ein F3-Befund ohne dokumentierte Risiko-Akzeptanz
+    3  Aufrufproblem (Datei fehlt, Datei unlesbar)
+
+Nur Standardbibliothek.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+if __package__ in (None, ""):
+    sys.path.insert(0, os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))))
+    from specforge_check import config as config_mod
+    from specforge_check import report, rules, spec as spec_mod
+else:
+    from . import config as config_mod
+    from . import report, rules, spec as spec_mod
+
+ACCEPT_BLOCK_RE = re.compile(r"^##\s+Risiko-Akzeptanz\s*:", re.M)
+
+
+def resolve(target):
+    """Gibt (spec_pfad, tasks_pfad) zurueck."""
+    if os.path.isdir(target):
+        spec_path = os.path.join(target, "spec.md")
+        tasks_path = os.path.join(target, "tasks.md")
+        return spec_path, tasks_path if os.path.isfile(tasks_path) else None
+    directory = os.path.dirname(os.path.abspath(target))
+    tasks_path = os.path.join(directory, "tasks.md")
+    return target, tasks_path if os.path.isfile(tasks_path) else None
+
+
+def load_acceptance(path):
+    """Blöcke aus dem CONDITIONAL-Akzeptanz-Protokoll.
+
+    Format siehe enforcement-engine.md, Abschnitt "CONDITIONAL-Akzeptanz-
+    Protokoll". Ein Block akzeptiert einen Befund, wenn er sowohl den
+    Pruefpunkt-Namen als auch den Betreff nennt.
+    """
+    if not path:
+        return []
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+    parts = ACCEPT_BLOCK_RE.split(text)
+    return [part for part in parts[1:] if part.strip()]
+
+
+def accepted_findings(findings, blocks):
+    accepted = []
+    for finding in findings:
+        if finding.level != "F3":
+            continue
+        for block in blocks:
+            if finding.check in block and finding.subject in block:
+                accepted.append(finding)
+                break
+    return accepted
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="specforge check",
+        description="Prueft eine spec.md gegen die strukturellen Regeln des "
+                    "SpecForge-Skills und meldet F-Stufen.")
+    parser.add_argument("pfad", help="spec.md oder Verzeichnis")
+    parser.add_argument("--tasks", help="tasks.md fuer die Traceability-"
+                                        "Pruefung (sonst neben der Spec)")
+    parser.add_argument("--config", help="specforge.json (sonst wird ab der "
+                                          "Spec aufwaerts gesucht)")
+    parser.add_argument("--nach-clarify", dest="after_clarify",
+                        action="store_true",
+                        help="offene [Annahme:]- und [Offen:]-Marker "
+                             "beanstanden")
+    parser.add_argument("--risiko-akzeptanz", dest="acceptance",
+                        help="Datei mit CONDITIONAL-Akzeptanz-Protokollen")
+    parser.add_argument("--json", dest="as_json", action="store_true",
+                        help="Befunde als JSON statt als Gate-Ausgabe")
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+
+    spec_path, tasks_path = resolve(args.pfad)
+    if args.tasks:
+        tasks_path = args.tasks
+    if not os.path.isfile(spec_path):
+        sys.stderr.write("FEHLER: keine spec.md unter %s\n" % spec_path)
+        return 3
+    if tasks_path and not os.path.isfile(tasks_path):
+        sys.stderr.write("FEHLER: tasks.md nicht gefunden: %s\n" % tasks_path)
+        return 3
+
+    config_path = args.config or config_mod.find(spec_path)
+    configuration = config_mod.load(config_path)
+
+    document = spec_mod.parse_spec(spec_path)
+    tasks = spec_mod.parse_tasks(tasks_path) if tasks_path else None
+
+    findings = rules.run(document, tasks, configuration, args.after_clarify)
+    accepted = accepted_findings(findings, load_acceptance(args.acceptance))
+
+    if args.as_json:
+        print(report.as_json(document, findings, accepted))
+    else:
+        print("specforge check %s" % spec_path)
+        print("Profil: %s · Perspektive: %s · Konfiguration: %s"
+              % (configuration.profile or "nicht gesetzt",
+                 configuration.perspective or "nicht gesetzt",
+                 config_path or "keine"))
+        if configuration.legacy:
+            print("Hinweis: specforge.json ohne severity_model — "
+                  "Legacy-Werte werden beim Einlesen einmal uebersetzt.")
+        print("")
+        for line in report.render(document, findings, tasks, accepted):
+            print(line)
+
+    open_levels = [f.level for f in findings if f not in accepted]
+    if "F4" in open_levels:
+        return 1
+    if "F3" in open_levels:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/specforge_check/__main__.py
+++ b/cli/specforge_check/__main__.py
@@ -19,19 +19,18 @@ Nur Standardbibliothek.
 
 import argparse
 import os
-import re
 import sys
 
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(
         os.path.abspath(__file__))))
+    from specforge_check import acceptance
     from specforge_check import config as config_mod
     from specforge_check import extensions, report, rules, spec as spec_mod
 else:
+    from . import acceptance
     from . import config as config_mod
     from . import extensions, report, rules, spec as spec_mod
-
-ACCEPT_BLOCK_RE = re.compile(r"^##\s+Risiko-Akzeptanz\s*:", re.M)
 
 
 def resolve(target):
@@ -43,33 +42,6 @@ def resolve(target):
     directory = os.path.dirname(os.path.abspath(target))
     tasks_path = os.path.join(directory, "tasks.md")
     return target, tasks_path if os.path.isfile(tasks_path) else None
-
-
-def load_acceptance(path):
-    """Blöcke aus dem CONDITIONAL-Akzeptanz-Protokoll.
-
-    Format siehe enforcement-engine.md, Abschnitt "CONDITIONAL-Akzeptanz-
-    Protokoll". Ein Block akzeptiert einen Befund, wenn er sowohl den
-    Pruefpunkt-Namen als auch den Betreff nennt.
-    """
-    if not path:
-        return []
-    with open(path, encoding="utf-8") as handle:
-        text = handle.read()
-    parts = ACCEPT_BLOCK_RE.split(text)
-    return [part for part in parts[1:] if part.strip()]
-
-
-def accepted_findings(findings, blocks):
-    accepted = []
-    for finding in findings:
-        if finding.level != "F3":
-            continue
-        for block in blocks:
-            if finding.check in block and finding.subject in block:
-                accepted.append(finding)
-                break
-    return accepted
 
 
 def build_parser():
@@ -87,7 +59,11 @@ def build_parser():
                         help="offene [Annahme:]- und [Offen:]-Marker "
                              "beanstanden")
     parser.add_argument("--risiko-akzeptanz", dest="acceptance",
-                        help="Datei mit CONDITIONAL-Akzeptanz-Protokollen")
+                        help="Datei mit Bloecken nach dem CONDITIONAL-"
+                             "Akzeptanz-Protokoll (enforcement-engine.md "
+                             "I.5). Ein Block hebt einen F3-Befund nur auf, "
+                             "wenn alle Pflichtfelder ausgefuellt sind und "
+                             "die Frist nicht abgelaufen ist.")
     parser.add_argument("--extensions", dest="extensions",
                         help="Wurzel mit references/custom/ (sonst dieses "
                              "Repository)")
@@ -108,6 +84,10 @@ def main(argv=None):
     if tasks_path and not os.path.isfile(tasks_path):
         sys.stderr.write("FEHLER: tasks.md nicht gefunden: %s\n" % tasks_path)
         return 3
+    if args.acceptance and not os.path.isfile(args.acceptance):
+        sys.stderr.write("FEHLER: Akzeptanz-Datei nicht gefunden: %s\n"
+                         % args.acceptance)
+        return 3
 
     config_path = args.config or config_mod.find(spec_path)
     configuration = config_mod.load(config_path)
@@ -121,10 +101,12 @@ def main(argv=None):
 
     findings = rules.run(document, tasks, configuration, args.after_clarify,
                          packages)
-    accepted = accepted_findings(findings, load_acceptance(args.acceptance))
+    accepted, acceptance_messages = acceptance.apply(findings,
+                                                     args.acceptance)
 
     if args.as_json:
-        print(report.as_json(document, findings, accepted))
+        print(report.as_json(document, findings, accepted,
+                             acceptance_messages))
     else:
         print("specforge check %s" % spec_path)
         print("Profil: %s · Perspektive: %s · Konfiguration: %s"
@@ -139,6 +121,11 @@ def main(argv=None):
         print("")
         for line in report.render(document, findings, tasks, accepted):
             print(line)
+        if acceptance_messages:
+            print("Risiko-Akzeptanz:")
+            for message in acceptance_messages:
+                print("  - %s" % message)
+            print("")
 
     open_levels = [f.level for f in findings if f not in accepted]
     if "F4" in open_levels:

--- a/cli/specforge_check/acceptance.py
+++ b/cli/specforge_check/acceptance.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""Liest die Risiko-Akzeptanz nach dem CONDITIONAL-Akzeptanz-Protokoll.
+
+Das Format steht in references/enforcement/enforcement-engine.md, Abschnitt
+I.5. Ein Block sieht so aus:
+
+    ## Risiko-Akzeptanz: T-002
+
+    **Gate:** G4 — Analyze → Implement
+    **Prüfpunkt:** orphan_task — T-002 ohne Story-Referenz
+    **F-Stufe:** F3 (gewichtiger Mangel)
+    **Risiko:** ...
+    **Akzeptiert durch:** Leitung Betrieb
+    **Kompensation:** ...
+    **Frist:** 2026-10-01
+    **Datum:** 2026-09-04
+
+Vorher genuegte es, dass Pruefpunktname und Betreff irgendwo im Text des
+Blocks als Teilstring vorkamen. Damit hob eine Datei, die die Akzeptanz
+ausdruecklich verweigert, das Gate auf, denn sie nennt beide Namen. Eine
+Freigabe, die kein Dokument verlangt, ist keine Freigabe.
+
+Ein Block hebt einen F3-Befund deshalb nur auf, wenn alle Pflichtfelder des
+Protokolls ausgefuellt sind, die Frist ein Datum im Format YYYY-MM-DD traegt
+und noch nicht abgelaufen ist, die F-Stufe zum Befund passt und die
+Ueberschrift den Betreff als eigenes Wort nennt. Was daran fehlt, meldet der
+Checker als eigene Zeile, statt es zu verschlucken.
+
+Nur Standardbibliothek.
+"""
+
+import datetime
+import re
+
+HEADING_RE = re.compile(r"^##\s+Risiko-Akzeptanz\s*:\s*(.*)$")
+FIELD_RE = re.compile(
+    r"^\*\*([^*:]+?)\*\*\s*:\s*(.*)$|^\*\*([^*:]+?):\*\*\s*(.*)$")
+LEVEL_RE = re.compile(r"\bF([0-5])\b")
+DATE_RE = re.compile(r"\b(\d{4})-(\d{2})-(\d{2})\b")
+
+# Die Pflichtfelder des Protokolls, in der Reihenfolge des Abschnitts I.5.
+REQUIRED = ("Gate", "Prüfpunkt", "F-Stufe", "Risiko", "Akzeptiert durch",
+            "Kompensation", "Frist", "Datum")
+
+
+class Block(object):
+    def __init__(self, subject, line):
+        self.subject = subject
+        self.line = line
+        self.fields = {}
+
+    def value(self, name):
+        return (self.fields.get(name) or "").strip()
+
+    @property
+    def level(self):
+        match = LEVEL_RE.search(self.value("F-Stufe"))
+        return "F" + match.group(1) if match else None
+
+    def date(self, name):
+        match = DATE_RE.search(self.value(name))
+        if not match:
+            return None
+        try:
+            return datetime.date(int(match.group(1)), int(match.group(2)),
+                                 int(match.group(3)))
+        except ValueError:
+            return None
+
+    def problems(self, today):
+        """Was diesen Block als Freigabe untauglich macht, im Klartext."""
+        found = []
+        missing = [name for name in REQUIRED if not self.value(name)]
+        if missing:
+            found.append("Pflichtfeld fehlt oder ist leer: %s"
+                         % ", ".join(missing))
+        if self.value("F-Stufe") and self.level is None:
+            found.append("F-Stufe %r ist keine Stufe zwischen F0 und F5"
+                         % self.value("F-Stufe"))
+        deadline = self.date("Frist")
+        if self.value("Frist") and deadline is None:
+            found.append("Frist %r ist kein Datum im Format YYYY-MM-DD"
+                         % self.value("Frist"))
+        elif deadline is not None and deadline < today:
+            found.append("Frist %s ist am %s abgelaufen"
+                         % (deadline.isoformat(), today.isoformat()))
+        if self.value("Datum") and self.date("Datum") is None:
+            found.append("Datum %r ist kein Datum im Format YYYY-MM-DD"
+                         % self.value("Datum"))
+        return found
+
+    def __repr__(self):
+        return "<Risiko-Akzeptanz %s, Zeile %d>" % (self.subject, self.line)
+
+
+def names(text, needle):
+    """True, wenn needle als eigenes Wort in text steht.
+
+    Teilstring genuegt nicht: 'T-002' darf nicht auf 'T-0021' passen.
+    """
+    if not needle:
+        return False
+    return re.search(r"(?<![\w.-])%s(?![\w.-])" % re.escape(needle),
+                     text) is not None
+
+
+def parse(path):
+    """Liest eine Akzeptanz-Datei und gibt die Bloecke zurueck."""
+    with open(path, encoding="utf-8") as handle:
+        lines = handle.read().split("\n")
+
+    blocks = []
+    current = None
+    for number, line in enumerate(lines, 1):
+        heading = HEADING_RE.match(line)
+        if heading:
+            current = Block(heading.group(1).strip(), number)
+            blocks.append(current)
+            continue
+        if line.startswith("## ") or line.startswith("# "):
+            current = None
+            continue
+        if current is None:
+            continue
+        field = FIELD_RE.match(line.strip())
+        if field:
+            key = field.group(1) or field.group(3)
+            value = field.group(2) if field.group(1) else field.group(4)
+            current.fields[key.strip()] = value.strip()
+    return blocks
+
+
+def matches(block, finding):
+    """Passt der Block zu diesem Befund?
+
+    Die Ueberschrift traegt den Betreff, so wie das Protokoll es vorsieht.
+    Der Pruefpunktname darf in der Ueberschrift oder im Feld Pruefpunkt
+    stehen; der Linter fuehrt beides in der Befundzeile.
+    """
+    if not names(block.subject, finding.subject):
+        return False
+    if not (names(block.subject, finding.check)
+            or names(block.value("Prüfpunkt"), finding.check)):
+        return False
+    return block.level == finding.level
+
+
+def apply(findings, path, today=None):
+    """Gibt (akzeptierte Befunde, Meldungen) zurueck.
+
+    Akzeptiert werden nur F3-Befunde: F4 blockiert ohne Ausnahme, und was
+    milder als F3 ist, braucht keine Freigabe.
+    """
+    if not path:
+        return [], []
+    today = today or datetime.date.today()
+    blocks = parse(path)
+    messages = []
+    accepted = []
+    used = set()
+
+    for finding in findings:
+        if finding.level != "F3":
+            continue
+        for index, block in enumerate(blocks):
+            if not matches(block, finding):
+                continue
+            problems = block.problems(today)
+            if problems:
+                for problem in problems:
+                    messages.append(
+                        "Block '%s' (Zeile %d) akzeptiert %s %s nicht: %s"
+                        % (block.subject, block.line, finding.check,
+                           finding.subject, problem))
+                continue
+            accepted.append(finding)
+            used.add(index)
+            break
+
+    for index, block in enumerate(blocks):
+        if index in used:
+            continue
+        problems = block.problems(today)
+        if problems:
+            # Ein Block, der zu keinem Befund passt und ausserdem
+            # unvollstaendig ist, hat bisher gar nichts gemeldet. Genau so
+            # sah die Datei aus, die die Akzeptanz verweigerte und trotzdem
+            # als Akzeptanz wirkte.
+            messages.append(
+                "Block '%s' (Zeile %d) ist keine gueltige Akzeptanz: %s"
+                % (block.subject, block.line, "; ".join(problems)))
+            continue
+        messages.append(
+            "Block '%s' (Zeile %d) passt zu keinem offenen F3-Befund"
+            % (block.subject, block.line))
+
+    if not blocks:
+        messages.append(
+            "Datei %s enthaelt keinen Block '## Risiko-Akzeptanz: <Betreff>'"
+            % path)
+    return accepted, messages

--- a/cli/specforge_check/config.py
+++ b/cli/specforge_check/config.py
@@ -34,6 +34,11 @@ class Config(object):
         return value if isinstance(value, str) else None
 
     @property
+    def extensions(self):
+        """Angabe aus specforge.json: None = nicht gesetzt, [] = keine."""
+        return self.data.get("extensions")
+
+    @property
     def legacy(self):
         """True, wenn die Datei noch kein severity_model fuehrt."""
         return bool(self.data) and "severity_model" not in self.data

--- a/cli/specforge_check/config.py
+++ b/cli/specforge_check/config.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Liest specforge.json und loest F-Stufen je Pruefpunkt auf.
+
+Die Aufloesung folgt enforcement-engine.md, Abschnitt "Perspektivenabhaengige
+F-Stufen": Perspektive aus specforge.json lesen, im severity-Objekt
+nachschlagen, bei Fehltreffer _default, ohne _default F3 als Fallback.
+
+Fehlt severity_model, ist das Projekt eine Altkonfiguration. Dann greift der
+Legacy-Uebersetzer aus severity.py — einmal beim Einlesen. Danach rechnet der
+Checker ausschliesslich mit F-Stufen.
+"""
+
+import json
+import os
+
+from . import severity
+
+FALLBACK = "F3"
+
+
+class Config(object):
+    def __init__(self, data=None, path=None):
+        self.data = data or {}
+        self.path = path
+
+    @property
+    def profile(self):
+        value = self.data.get("profile")
+        return value.lower() if isinstance(value, str) else None
+
+    @property
+    def perspective(self):
+        value = self.data.get("perspective")
+        return value if isinstance(value, str) else None
+
+    @property
+    def legacy(self):
+        """True, wenn die Datei noch kein severity_model fuehrt."""
+        return bool(self.data) and "severity_model" not in self.data
+
+    def _entry(self, check):
+        for gate in self.data.get("checks_config", {}).values():
+            if isinstance(gate, dict) and check in gate:
+                return gate[check]
+        return None
+
+    def severity_for(self, check, default):
+        """F-Stufe eines Pruefpunkts: Konfiguration schlaegt Default."""
+        entry = self._entry(check)
+        if not isinstance(entry, dict):
+            return default
+
+        if "severity" in entry:
+            value = entry["severity"]
+            if isinstance(value, dict):
+                if self.perspective and self.perspective in value:
+                    resolved = severity.normalise(value[self.perspective])
+                    if resolved:
+                        return resolved
+                if "_default" in value:
+                    resolved = severity.normalise(value["_default"])
+                    if resolved:
+                        return resolved
+                return FALLBACK
+            resolved = severity.normalise(value)
+            if resolved:
+                return resolved
+
+        # Altkonfiguration ohne severity: Boolean-Logik uebersetzen.
+        if "required" in entry:
+            if entry["required"]:
+                return "F4"
+            if entry.get("skip_reason_required"):
+                return "F3"
+            return "F1"
+        return default
+
+
+def load(path):
+    """Laedt eine specforge.json. Fehlt sie, gilt die leere Konfiguration."""
+    if not path or not os.path.isfile(path):
+        return Config()
+    with open(path, encoding="utf-8") as handle:
+        return Config(json.load(handle), path)
+
+
+def find(start):
+    """Sucht specforge.json neben der Spec und in den Elternverzeichnissen."""
+    directory = os.path.abspath(start if os.path.isdir(start)
+                                else os.path.dirname(start))
+    while True:
+        candidate = os.path.join(directory, "specforge.json")
+        if os.path.isfile(candidate):
+            return candidate
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            return None
+        directory = parent

--- a/cli/specforge_check/config.py
+++ b/cli/specforge_check/config.py
@@ -6,8 +6,8 @@ F-Stufen": Perspektive aus specforge.json lesen, im severity-Objekt
 nachschlagen, bei Fehltreffer _default, ohne _default F3 als Fallback.
 
 Fehlt severity_model, ist das Projekt eine Altkonfiguration. Dann greift der
-Legacy-Uebersetzer aus severity.py — einmal beim Einlesen. Danach rechnet der
-Checker ausschliesslich mit F-Stufen.
+Legacy-Uebersetzer aus severity.py, und zwar genau einmal beim Einlesen.
+Danach rechnet der Checker ausschliesslich mit F-Stufen.
 """
 
 import json

--- a/cli/specforge_check/extensions.py
+++ b/cli/specforge_check/extensions.py
@@ -7,7 +7,7 @@ eine Spalte, dazu die Pflicht-Spalte _default. Genau das ist die Tabelle, die
 in der Session entscheidet, welche F-Stufe eine fehlende Anforderung bekommt.
 
 Der Checker liest sie, statt sie zu wiederholen. Eine Zelle kann mehrere
-Stufen nennen ("F4 (TLPT) / F3", "F4 (PII) / F3") — die Bedingung dahinter
+Stufen nennen ("F4 (TLPT) / F3", "F4 (PII) / F3"), und die Bedingung dahinter
 ist fachlich, nicht strukturell entscheidbar. Zulaessig sind dann beide
 Stufen; falsch ist nur eine Stufe, die in der Zelle gar nicht vorkommt.
 """

--- a/cli/specforge_check/extensions.py
+++ b/cli/specforge_check/extensions.py
@@ -6,7 +6,14 @@ einen Abschnitt "F-Stufen-Zuordnung": je Kategorie eine Zeile, je Perspektive
 eine Spalte, dazu die Pflicht-Spalte _default. Genau das ist die Tabelle, die
 in der Session entscheidet, welche F-Stufe eine fehlende Anforderung bekommt.
 
-Der Checker liest sie, statt sie zu wiederholen. Eine Zelle kann mehrere
+Welche Pakete gelten, sagt das Feld extensions in der specforge.json. Es ist
+fehlertolerant nach der falschen Seite gewesen: "@DORA" statt "@dora" ergab
+"Extensions: keine" und liess die F-Stufen-Pruefung kommentarlos entfallen,
+eine leere Liste galt als "nicht gesetzt" und lud alles. Jetzt werden die
+Namen normalisiert, ein unbekannter Name ist ein Aufrufproblem, und die
+leere Liste heisst ausdruecklich "keine Extension".
+
+Der Checker liest die Tabelle, statt sie zu wiederholen. Eine Zelle kann mehrere
 Stufen nennen ("F4 (TLPT) / F3", "F4 (PII) / F3"), und die Bedingung dahinter
 ist fachlich, nicht strukturell entscheidbar. Zulaessig sind dann beide
 Stufen; falsch ist nur eine Stufe, die in der Zelle gar nicht vorkommt.
@@ -22,6 +29,10 @@ HEADING_RE = re.compile(r"^#+\s*(.*)$")
 
 SECTION = "F-Stufen-Zuordnung"
 DEFAULT_COLUMN = "_default"
+
+
+class ExtensionFehler(ValueError):
+    """Die Angabe extensions in der specforge.json ist nicht benutzbar."""
 
 
 def split_row(line):
@@ -70,26 +81,81 @@ def parse_manifest(path):
     return table
 
 
-def load(root, names=None):
-    """Laedt alle Extension-Pakete unter references/custom/.
+def normalise_name(value):
+    """'@DORA', 'DORA', ' dora ' und '@dora' sind derselbe Name."""
+    return str(value).strip().casefold().lstrip("@")
 
-    names schraenkt auf die in specforge.json aktivierten Pakete ein.
+
+def available(base):
+    return sorted(entry for entry in os.listdir(base)
+                  if entry.startswith("@")
+                  and os.path.isdir(os.path.join(base, entry)))
+
+
+def load(root, names=None):
+    """Laedt die Extension-Pakete unter references/custom/.
+
+    names ist die Angabe aus specforge.json:
+
+        None  Feld nicht gesetzt, alle vorhandenen Pakete gelten
+        []    ausdruecklich keine Extension
+        [...] genau diese, unabhaengig von Schreibweise und fuehrendem @
+
+    Ein Name, zu dem es kein Paket gibt, ist ein Aufrufproblem und keine
+    Kleinigkeit: die Datei wollte eine Regulatorik aktivieren, und ein
+    stilles Ignorieren nimmt genau die Pruefung heraus, um derentwillen sie
+    dasteht.
     """
     base = os.path.join(root, "references", "custom")
     if not os.path.isdir(base):
+        if names:
+            raise ExtensionFehler(
+                "kein Verzeichnis references/custom/ unter %s, aber "
+                "extensions verlangt %s" % (root, ", ".join(map(str, names))))
         return {}
+
+    entries = available(base)
+    known = dict((normalise_name(entry), entry) for entry in entries)
+
+    wanted = None
+    if names is not None:
+        if not isinstance(names, (list, tuple)):
+            raise ExtensionFehler(
+                "extensions muss eine Liste von Namen sein, gefunden %r"
+                % (names,))
+        wanted = {}
+        for name in names:
+            if not isinstance(name, str) or not name.strip():
+                raise ExtensionFehler(
+                    "extensions enthaelt einen leeren oder nicht "
+                    "textwertigen Eintrag: %r" % (name,))
+            wanted[normalise_name(name)] = name
+        unknown = [wanted[key] for key in sorted(wanted) if key not in known]
+        if unknown:
+            raise ExtensionFehler(
+                "unbekannte Extension %s. Vorhanden unter references/custom/: "
+                "%s" % (", ".join("'%s'" % item for item in unknown),
+                        ", ".join(entries) or "keine"))
+
     packages = {}
-    for entry in sorted(os.listdir(base)):
-        if not entry.startswith("@"):
-            continue
-        if names and entry not in names and entry.lstrip("@") not in names:
+    for entry in entries:
+        requested = wanted is not None
+        if requested and normalise_name(entry) not in wanted:
             continue
         manifest = os.path.join(base, entry, "manifest.md")
         if not os.path.isfile(manifest):
+            if requested:
+                raise ExtensionFehler(
+                    "Extension '%s' hat keine manifest.md" % entry)
             continue
         table = parse_manifest(manifest)
-        if table:
-            packages[entry] = table
+        if not table:
+            if requested:
+                raise ExtensionFehler(
+                    "Extension '%s' fuehrt keinen Abschnitt '%s'"
+                    % (entry, SECTION))
+            continue
+        packages[entry] = table
     return packages
 
 

--- a/cli/specforge_check/extensions.py
+++ b/cli/specforge_check/extensions.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Liest die F-Stufen-Tabellen der Regulatorik-Extensions.
+
+Jede Extension unter references/custom/@name/ fuehrt in ihrer manifest.md
+einen Abschnitt "F-Stufen-Zuordnung": je Kategorie eine Zeile, je Perspektive
+eine Spalte, dazu die Pflicht-Spalte _default. Genau das ist die Tabelle, die
+in der Session entscheidet, welche F-Stufe eine fehlende Anforderung bekommt.
+
+Der Checker liest sie, statt sie zu wiederholen. Eine Zelle kann mehrere
+Stufen nennen ("F4 (TLPT) / F3", "F4 (PII) / F3") — die Bedingung dahinter
+ist fachlich, nicht strukturell entscheidbar. Zulaessig sind dann beide
+Stufen; falsch ist nur eine Stufe, die in der Zelle gar nicht vorkommt.
+"""
+
+import os
+import re
+
+TABLE_ROW_RE = re.compile(r"^\|(.+)\|\s*$")
+BOLD_CODE_RE = re.compile(r"\*\*([A-Z]{2,5})\*\*")
+F_LEVEL_RE = re.compile(r"\bF\s?([0-5])\b")
+HEADING_RE = re.compile(r"^#+\s*(.*)$")
+
+SECTION = "F-Stufen-Zuordnung"
+DEFAULT_COLUMN = "_default"
+
+
+def split_row(line):
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def parse_manifest(path):
+    """Gibt {kategorie: {spalte: {F-Stufen}}} zurueck."""
+    with open(path, encoding="utf-8") as handle:
+        lines = handle.read().split("\n")
+
+    start = None
+    for index, line in enumerate(lines):
+        heading = HEADING_RE.match(line)
+        if heading and SECTION in heading.group(1):
+            start = index
+            break
+    if start is None:
+        return {}
+
+    header = None
+    table = {}
+    for line in lines[start:]:
+        if HEADING_RE.match(line) and header is not None:
+            break
+        if not TABLE_ROW_RE.match(line):
+            continue
+        cells = split_row(line)
+        if header is None:
+            if cells and cells[0].lower() == "kategorie":
+                header = [cell.strip("` ") for cell in cells[1:]]
+            continue
+        if set("".join(cells)) <= set("-: "):
+            continue
+        code = BOLD_CODE_RE.search(cells[0])
+        name = code.group(1) if code else cells[0]
+        row = {}
+        for position, cell in enumerate(cells[1:]):
+            if position >= len(header):
+                break
+            levels = set("F" + level for level in F_LEVEL_RE.findall(cell))
+            if levels:
+                row[header[position]] = levels
+        if row:
+            table[name] = row
+    return table
+
+
+def load(root, names=None):
+    """Laedt alle Extension-Pakete unter references/custom/.
+
+    names schraenkt auf die in specforge.json aktivierten Pakete ein.
+    """
+    base = os.path.join(root, "references", "custom")
+    if not os.path.isdir(base):
+        return {}
+    packages = {}
+    for entry in sorted(os.listdir(base)):
+        if not entry.startswith("@"):
+            continue
+        if names and entry not in names and entry.lstrip("@") not in names:
+            continue
+        manifest = os.path.join(base, entry, "manifest.md")
+        if not os.path.isfile(manifest):
+            continue
+        table = parse_manifest(manifest)
+        if table:
+            packages[entry] = table
+    return packages
+
+
+def allowed_levels(packages, category, perspective):
+    """Zulaessige F-Stufen einer Kategorie fuer eine Perspektive.
+
+    Aufloesung wie in enforcement-engine.md: Perspektive, sonst _default.
+    Kennt keine Extension die Kategorie, gibt die Funktion None zurueck —
+    dann ist die Stufe nicht pruefbar und der Checker schweigt.
+
+    Kategorie-Kuerzel sind nicht global eindeutig: IRM heisst bei @dora
+    IKT-Risikomanagement und bei @bait Informationsrisikomanagement, mit
+    verschiedenen Stufen. Sind mehrere Extensions aktiv, die dasselbe Kuerzel
+    fuehren, gilt die Vereinigung ihrer Stufen. Der Checker beanstandet dann
+    nur eine Stufe, die keine der beiden Extensions vorsieht. Wer das
+    scharfstellen will, aktiviert in specforge.json die Extension, die
+    gemeint ist.
+    """
+    levels = set()
+    for table in packages.values():
+        row = table.get(category)
+        if not row:
+            continue
+        if perspective and perspective in row:
+            levels |= row[perspective]
+        elif DEFAULT_COLUMN in row:
+            levels |= row[DEFAULT_COLUMN]
+    return levels or None

--- a/cli/specforge_check/report.py
+++ b/cli/specforge_check/report.py
@@ -26,12 +26,21 @@ LABELS = {
     "nfr_severity": "F-Stufe der NFR-Luecke",
 }
 
+# Die AP-07-Pruefpunkte. Sie brauchen eine tasks.md; ohne sie hat dieser
+# Lauf sie nicht angesehen.
+TRACEABILITY_CHECKS = ("orphan_task", "orphan_story")
+
+# Die Stufe "nicht anwendbar". Symbol und Gate-Ergebnis stehen in
+# severity.GATE und werden von dort geholt, damit die F-Stufen-Tabelle aus
+# enforcement-engine.md genau eine Abbildung im Code hat.
+SKIP_LEVEL = "F5"
+
 GATES = (
     ("G1", "Specify → Clarify",
      ("no_stories", "id_schema", "id_unique", "ears_coverage",
       "gherkin_minimum", "vague_terms", "sophist", "open_marker",
       "nfr_gap", "nfr_severity")),
-    ("G4", "Analyze → Implement", ("orphan_task", "orphan_story")),
+    ("G4", "Analyze → Implement", TRACEABILITY_CHECKS),
 )
 
 RULE = "─"
@@ -60,11 +69,25 @@ def render(spec, findings, tasks, accepted):
         by_check.setdefault(finding.check, []).append(finding)
 
     for gate, title, checks in GATES:
-        active = [c for c in checks if c in by_check]
-        if gate == "G4" and tasks is None:
-            continue
         out.append(line("Gate %s: %s" % (gate, title)))
+        if gate == "G4" and tasks is None:
+            # Frueher fiel das Gate hier kommentarlos aus der Ausgabe. Eine
+            # geloeschte oder falsch abgelegte tasks.md nahm damit die
+            # AP-07-Pruefung heraus, und uebrig blieb ein Bericht, der nach
+            # bestandenem Lauf aussah. Das Gate steht jetzt da und sagt,
+            # dass es nichts geprueft hat.
+            symbol, result = _symbol(SKIP_LEVEL)
+            out.append("%s [%s] keine tasks.md gefunden: %s nicht geprueft"
+                       % (symbol, SKIP_LEVEL,
+                          " und ".join(LABELS[c] for c in checks)))
+            out.append("   └─ tasks.md neben die spec.md legen oder mit "
+                       "--tasks angeben; dieser Lauf sagt nichts ueber die "
+                       "Nachverfolgbarkeit")
+            out.append(line("Ergebnis: %s" % result))
+            out.append("")
+            continue
         printed = False
+        skipped = False
         for check in checks:
             hits = by_check.get(check)
             if not hits:
@@ -90,13 +113,15 @@ def render(spec, findings, tasks, accepted):
             if empty:
                 # "Alle Pruefpunkte erfuellt" bei null Pruefgegenstaenden
                 # ist eine Aussage ueber nichts. Sie wird hier nicht
-                # gemacht.
-                out.append("⏭️ [F5] Nichts Pruefbares gefunden: %s" % scope)
+                # gemacht, und das Ergebnis heisst dann auch nicht PASS.
+                out.append("%s [%s] Nichts Pruefbares gefunden: %s"
+                           % (_symbol(SKIP_LEVEL)[0], SKIP_LEVEL, scope))
+                skipped = True
             else:
                 out.append("✅ [F0] Alle Pruefpunkte erfuellt: %s" % scope)
         levels = [f.level for f in findings
                   if f.check in checks and f not in accepted]
-        result = gate_result(levels)
+        result = _symbol(SKIP_LEVEL)[1] if skipped else gate_result(levels)
         out.append(line("Ergebnis: %s" % result))
         out.append("")
 
@@ -108,10 +133,21 @@ def _symbol(level):
     return symbol, result
 
 
-def as_json(spec, findings, accepted, acceptance_messages=()):
+def skipped_checks(tasks):
+    """Pruefpunkte, die dieser Lauf nicht angesehen hat.
+
+    Ohne tasks.md laeuft AP-07 nicht. Wer die Ausgabe als JSON
+    weiterverarbeitet, soll das an der Ausgabe sehen und nicht daran, dass
+    zwei Pruefpunkte in findings fehlen.
+    """
+    return [] if tasks is not None else list(TRACEABILITY_CHECKS)
+
+
+def as_json(spec, findings, accepted, acceptance_messages=(), tasks=None):
     return json.dumps({
         "spec": spec.path,
         "stories": [story.id for story in spec.stories],
+        "skipped_checks": skipped_checks(tasks),
         "acceptance_problems": list(acceptance_messages),
         "findings": [{
             "check": finding.check,

--- a/cli/specforge_check/report.py
+++ b/cli/specforge_check/report.py
@@ -21,12 +21,14 @@ LABELS = {
     "id_unique": "ID-Eindeutigkeit",
     "orphan_task": "Orphan Task (AP-07)",
     "orphan_story": "Orphan Spec (AP-07)",
+    "nfr_gap": "NFR-Luecke",
+    "nfr_severity": "F-Stufe der NFR-Luecke",
 }
 
 GATES = (
     ("G1", "Specify → Clarify",
      ("id_schema", "id_unique", "ears_coverage", "gherkin_minimum",
-      "vague_terms", "sophist", "open_marker")),
+      "vague_terms", "sophist", "open_marker", "nfr_gap", "nfr_severity")),
     ("G4", "Analyze → Implement", ("orphan_task", "orphan_story")),
 )
 

--- a/cli/specforge_check/report.py
+++ b/cli/specforge_check/report.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Ausgabe im Gate-Ergebnis-Format.
+
+Das Format steht in references/enforcement/enforcement-engine.md, Abschnitt
+"Gate-Ergebnis-Format". Wer die Ausgabe des Checkers neben ein
+Session-Protokoll legt, soll dieselbe Form sehen, sonst sind die beiden
+Enforcement-Wege nicht vergleichbar.
+"""
+
+import json
+
+from . import severity
+
+LABELS = {
+    "ears_coverage": "EARS-Formulierung",
+    "gherkin_minimum": "Gherkin-Szenarien",
+    "vague_terms": "Vage Begriffe (AP-04)",
+    "sophist": "SOPHIST-Verletzung (AP-08)",
+    "open_marker": "Offene Marker",
+    "id_schema": "ID-Schema",
+    "id_unique": "ID-Eindeutigkeit",
+    "orphan_task": "Orphan Task (AP-07)",
+    "orphan_story": "Orphan Spec (AP-07)",
+}
+
+GATES = (
+    ("G1", "Specify → Clarify",
+     ("id_schema", "id_unique", "ears_coverage", "gherkin_minimum",
+      "vague_terms", "sophist", "open_marker")),
+    ("G4", "Analyze → Implement", ("orphan_task", "orphan_story")),
+)
+
+RULE = "─"
+
+
+def line(text, width=46):
+    filler = max(1, width - len(text) - 4)
+    return "── %s %s" % (text, RULE * filler)
+
+
+def gate_result(levels):
+    if "F4" in levels:
+        return "FAIL"
+    if "F3" in levels:
+        return "CONDITIONAL"
+    if "F2" in levels:
+        return "WARNING"
+    return "PASS"
+
+
+def render(spec, findings, tasks, accepted):
+    """Gibt die Textausgabe als Liste von Zeilen zurueck."""
+    out = []
+    by_check = {}
+    for finding in findings:
+        by_check.setdefault(finding.check, []).append(finding)
+
+    for gate, title, checks in GATES:
+        active = [c for c in checks if c in by_check]
+        if gate == "G4" and tasks is None:
+            continue
+        out.append(line("Gate %s: %s" % (gate, title)))
+        printed = False
+        for check in checks:
+            hits = by_check.get(check)
+            if not hits:
+                continue
+            printed = True
+            for finding in sorted(hits, key=lambda f: severity.rank(f.level)):
+                symbol, result = _symbol(finding.level)
+                suffix = " — akzeptiert" if finding in accepted else ""
+                out.append("%s [%s] %s: %s — %s — %s%s"
+                           % (symbol, finding.level, LABELS[check],
+                              finding.subject, finding.message, result,
+                              suffix))
+                if finding.remedy:
+                    out.append("   └─ %s" % finding.remedy)
+        if not printed:
+            scope = ("%d/%d Stories" % (len(spec.stories), len(spec.stories))
+                     if gate == "G1" else "%d Tasks" % len(tasks or []))
+            out.append("✅ [F0] Alle Pruefpunkte erfuellt: %s" % scope)
+        levels = [f.level for f in findings
+                  if f.check in checks and f not in accepted]
+        result = gate_result(levels)
+        out.append(line("Ergebnis: %s" % result))
+        out.append("")
+
+    return out
+
+
+def _symbol(level):
+    result, symbol, _ = severity.GATE[level][0], severity.GATE[level][1], None
+    return symbol, result
+
+
+def as_json(spec, findings, accepted):
+    return json.dumps({
+        "spec": spec.path,
+        "stories": [story.id for story in spec.stories],
+        "findings": [{
+            "check": finding.check,
+            "severity": finding.level,
+            "subject": finding.subject,
+            "line": finding.line,
+            "message": finding.message,
+            "accepted": finding in accepted,
+        } for finding in sorted(
+            findings, key=lambda f: (severity.rank(f.level), f.check,
+                                     f.subject))],
+    }, ensure_ascii=False, indent=2, sort_keys=False)

--- a/cli/specforge_check/report.py
+++ b/cli/specforge_check/report.py
@@ -12,6 +12,7 @@ import json
 from . import severity
 
 LABELS = {
+    "no_stories": "Keine pruefbare Story",
     "ears_coverage": "EARS-Formulierung",
     "gherkin_minimum": "Gherkin-Szenarien",
     "vague_terms": "Vage Begriffe (AP-04)",
@@ -27,8 +28,9 @@ LABELS = {
 
 GATES = (
     ("G1", "Specify → Clarify",
-     ("id_schema", "id_unique", "ears_coverage", "gherkin_minimum",
-      "vague_terms", "sophist", "open_marker", "nfr_gap", "nfr_severity")),
+     ("no_stories", "id_schema", "id_unique", "ears_coverage",
+      "gherkin_minimum", "vague_terms", "sophist", "open_marker",
+      "nfr_gap", "nfr_severity")),
     ("G4", "Analyze → Implement", ("orphan_task", "orphan_story")),
 )
 
@@ -78,9 +80,20 @@ def render(spec, findings, tasks, accepted):
                 if finding.remedy:
                     out.append("   └─ %s" % finding.remedy)
         if not printed:
-            scope = ("%d/%d Stories" % (len(spec.stories), len(spec.stories))
-                     if gate == "G1" else "%d Tasks" % len(tasks or []))
-            out.append("✅ [F0] Alle Pruefpunkte erfuellt: %s" % scope)
+            if gate == "G1":
+                scope = "%d/%d Stories" % (len(spec.stories),
+                                           len(spec.stories))
+                empty = not spec.stories
+            else:
+                scope = "%d Tasks" % len(tasks or [])
+                empty = not tasks
+            if empty:
+                # "Alle Pruefpunkte erfuellt" bei null Pruefgegenstaenden
+                # ist eine Aussage ueber nichts. Sie wird hier nicht
+                # gemacht.
+                out.append("⏭️ [F5] Nichts Pruefbares gefunden: %s" % scope)
+            else:
+                out.append("✅ [F0] Alle Pruefpunkte erfuellt: %s" % scope)
         levels = [f.level for f in findings
                   if f.check in checks and f not in accepted]
         result = gate_result(levels)

--- a/cli/specforge_check/report.py
+++ b/cli/specforge_check/report.py
@@ -108,10 +108,11 @@ def _symbol(level):
     return symbol, result
 
 
-def as_json(spec, findings, accepted):
+def as_json(spec, findings, accepted, acceptance_messages=()):
     return json.dumps({
         "spec": spec.path,
         "stories": [story.id for story in spec.stories],
+        "acceptance_problems": list(acceptance_messages),
         "findings": [{
             "check": finding.check,
             "severity": finding.level,

--- a/cli/specforge_check/rules.py
+++ b/cli/specforge_check/rules.py
@@ -14,6 +14,11 @@ im Payload:
   id_unique         F4  doppelte ID bricht die Nachverfolgbarkeit
   orphan_task       F3  AP-07, references/08-management.md TM-02
   orphan_story      F3  AP-07, references/08-management.md
+  nfr_severity      F3  falsch eingestufte NFR-Luecke, Gate G1 NFR-Scan
+
+Die Regel nfr_gap hat keine Default-Stufe. Ihre F-Stufe steht im Marker
+selbst ([NFR-Lücke F4: IRM-01 — ...]), so wie enforcement-engine.md das
+NFR-Luecken-Format festlegt.
 
 Wer einen anderen Wert braucht, setzt ihn in checks_config, nicht hier.
 """
@@ -59,7 +64,11 @@ DEFAULTS = {
     "id_unique": "F4",
     "orphan_task": "F3",
     "orphan_story": "F3",
+    "nfr_severity": "F3",
 }
+
+# Kategorie-Praefix einer NFR-Luecke: IRM-01, DAT-03, AVA-02.
+NFR_ID_RE = re.compile(r"^([A-Z]{2,5})-(\d{2})\b")
 
 GHERKIN_MINIMUM = 2
 
@@ -234,7 +243,44 @@ def check_traceability(spec, tasks, config):
     return findings
 
 
-def run(spec, tasks, config, after_clarify=False):
+def check_nfr_gaps(spec, config, packages):
+    """Dokumentierte NFR-Luecken und ihre F-Stufe.
+
+    Eine Luecke ist ein Befund in der Stufe, die der Marker nennt. Zusaetzlich
+    wird die Stufe gegen die F-Stufen-Tabelle der aktiven Extension geprueft:
+    dieselbe Kategorie bekommt je nach Perspektive eine andere Stufe, und
+    genau das ist der Punkt, an dem eine pauschale Einstufung ein Gate zu
+    hart oder zu weich macht.
+    """
+    from .extensions import allowed_levels
+    findings = []
+    severity_level = level_for(config, "nfr_severity")
+    for story in spec.stories:
+        for number, level, text in story.nfr_gaps:
+            identifier = text.split("—")[0].strip()
+            match = NFR_ID_RE.match(identifier)
+            category = match.group(1) if match else None
+            findings.append(Finding(
+                "nfr_gap", level, identifier or story.id,
+                "NFR-Luecke in Story %s" % story.id, number,
+                "Anforderung spezifizieren oder F5 mit Begruendung "
+                "dokumentieren"))
+            if not category or not packages:
+                continue
+            allowed = allowed_levels(packages, category,
+                                     config.perspective)
+            if allowed and level not in allowed:
+                findings.append(Finding(
+                    "nfr_severity", severity_level, identifier,
+                    "als %s eingestuft, die Perspektive %s verlangt %s"
+                    % (level, config.perspective or "_default",
+                       " oder ".join(sorted(allowed))), number,
+                    "F-Stufe aus der F-Stufen-Zuordnung der Extension "
+                    "uebernehmen"))
+    return findings
+
+
+def run(spec, tasks, config, after_clarify=False, packages=None):
     findings = []
     findings.extend(check_ids(spec, config))
     findings.extend(check_ears(spec, config))
@@ -242,5 +288,6 @@ def run(spec, tasks, config, after_clarify=False):
     findings.extend(check_vague(spec, config))
     findings.extend(check_sophist(spec, config))
     findings.extend(check_markers(spec, config, after_clarify))
+    findings.extend(check_nfr_gaps(spec, config, packages or {}))
     findings.extend(check_traceability(spec, tasks, config))
     return findings

--- a/cli/specforge_check/rules.py
+++ b/cli/specforge_check/rules.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+"""Die Regeln, die ohne Sprachmodell entscheidbar sind.
+
+Jede Regel traegt den Namen, unter dem sie in checks_config konfigurierbar
+ist, und eine Default-F-Stufe. Die Defaults sind nicht erfunden, sie stehen
+im Payload:
+
+  ears_coverage     F4  Gate G1, references/01-specify.md, 07-review.md
+  gherkin_minimum   F4  Gate G1, references/09-discover.md, 08-management.md
+  vague_terms       F4  AP-04, Gate G2
+  sophist           F3  AP-08
+  open_marker       F3  SKILL.md, globale Regel 11
+  id_schema         F1  references/01-specify.md, 07-review.md RQ-08
+  id_unique         F4  doppelte ID bricht die Nachverfolgbarkeit
+  orphan_task       F3  AP-07, references/08-management.md TM-02
+  orphan_story      F3  AP-07, references/08-management.md
+
+Wer einen anderen Wert braucht, setzt ihn in checks_config, nicht hier.
+"""
+
+import re
+
+# AP-04, Blocklist aus SKILL.md, globale Regel 4. Die Endungen decken die
+# deutsche Beugung ab, ohne Woerter zu treffen, die den Stamm nur enthalten
+# ("Sicherheit", "sicherstellen", "Vereinfachung").
+VAGUE_TERMS = {
+    "schnell": r"schnell(?:e[nmrs]?|es)?",
+    "viele": r"viel(?:e[nmrs]?|es)?",
+    "einfach": r"einfach(?:e[nmrs]?|es)?",
+    "skalierbar": r"skalierbar(?:e[nmrs]?|es)?",
+    "sicher": r"sicher(?:e[nmrs]?|es)?",
+    "zuverlässig": r"zuverlässig(?:e[nmrs]?|es)?",
+}
+
+# AP-08, SOPHIST-Blocklist aus enforcement-engine.md. Aufgenommen sind nur
+# die eindeutigen Trigger. "z.B." und "u.a." stehen dort mit der Einschraenkung
+# "als einzige Spezifikation" und sind ohne Bedeutungspruefung nicht
+# entscheidbar; sie bleiben der Session ueberlassen.
+SOPHIST_TERMS = {
+    "ggf.": r"ggf\.",
+    "evtl.": r"evtl\.",
+    "etc.": r"etc\.",
+    "usw.": r"usw\.",
+    "zeitnah": r"zeitnah",
+    "umgehend": r"umgehend",
+    "normalerweise": r"normalerweise",
+    "in der Regel": r"in der Regel",
+    "falls möglich": r"falls möglich",
+    "regelmäßig": r"regelmäßig",
+}
+
+DEFAULTS = {
+    "ears_coverage": "F4",
+    "gherkin_minimum": "F4",
+    "vague_terms": "F4",
+    "sophist": "F3",
+    "open_marker": "F3",
+    "id_schema": "F1",
+    "id_unique": "F4",
+    "orphan_task": "F3",
+    "orphan_story": "F3",
+}
+
+GHERKIN_MINIMUM = 2
+
+
+class Finding(object):
+    def __init__(self, check, level, subject, message, line=None,
+                 remedy=None):
+        self.check = check
+        self.level = level
+        self.subject = subject
+        self.message = message
+        self.line = line
+        self.remedy = remedy
+
+    def __repr__(self):
+        return "<%s %s %s>" % (self.level, self.check, self.subject)
+
+
+def _compiled(mapping):
+    return [(label, re.compile(r"\b" + pattern + r"\b", re.I))
+            for label, pattern in sorted(mapping.items())]
+
+
+VAGUE_RE = _compiled(VAGUE_TERMS)
+SOPHIST_RE = [(label, re.compile(pattern, re.I))
+              for label, pattern in sorted(SOPHIST_TERMS.items())]
+
+
+def level_for(config, check):
+    return config.severity_for(check, DEFAULTS[check])
+
+
+def check_ears(spec, config):
+    level = level_for(config, "ears_coverage")
+    findings = []
+    from .spec import known_pattern, EARS_PATTERNS
+    for story in spec.stories:
+        if story.pattern is None:
+            findings.append(Finding(
+                "ears_coverage", level, story.id,
+                "kein Feld **Pattern:** in der Story", story.line,
+                "Pattern ergaenzen, erlaubt: " + ", ".join(EARS_PATTERNS)))
+        elif not known_pattern(story.pattern):
+            findings.append(Finding(
+                "ears_coverage", level, story.id,
+                "unbekanntes EARS-Pattern %r" % story.pattern, story.line,
+                "erlaubt: " + ", ".join(EARS_PATTERNS)))
+    return findings
+
+
+def check_gherkin(spec, config):
+    level = level_for(config, "gherkin_minimum")
+    findings = []
+    for story in spec.stories:
+        count = len(story.scenarios)
+        if count < GHERKIN_MINIMUM:
+            findings.append(Finding(
+                "gherkin_minimum", level, story.id,
+                "%d Szenario/Szenarien, mindestens %d verlangt"
+                % (count, GHERKIN_MINIMUM), story.line,
+                "Fehlerfall als zweites Scenario ergaenzen (AP-06)"))
+    return findings
+
+
+# Marker sind ausdruecklich vorlaeufig. Ein vager Begriff innerhalb von
+# [Annahme: ...] oder [Offen: ...] ist kein AP-04-Befund, sondern genau das,
+# wofuer der Marker da ist. Er faellt in Clarify auf, nicht hier.
+PROVISIONAL_RE = re.compile(r"\[(?:Annahme|Offen|NFR-Lücke)[^\]]*\]")
+
+
+def _scan(story, patterns, check, level, kind, remedy):
+    findings = []
+    seen = set()
+    for number, line in story.lines:
+        text = PROVISIONAL_RE.sub("", line)
+        for label, expression in patterns:
+            if label in seen:
+                continue
+            if expression.search(text):
+                seen.add(label)
+                findings.append(Finding(
+                    check, level, story.id, "%s %r" % (kind, label), number,
+                    remedy))
+    return findings
+
+
+def check_vague(spec, config):
+    level = level_for(config, "vague_terms")
+    findings = []
+    for story in spec.stories:
+        findings.extend(_scan(story, VAGUE_RE, "vague_terms", level,
+                              "vager Begriff",
+                              "durch messbaren Wert ersetzen (AP-04)"))
+    return findings
+
+
+def check_sophist(spec, config):
+    level = level_for(config, "sophist")
+    findings = []
+    for story in spec.stories:
+        findings.extend(_scan(story, SOPHIST_RE, "sophist", level,
+                              "unbestimmte Formulierung",
+                              "Bedingung oder Aufzaehlung ausschreiben "
+                              "(AP-08)"))
+    return findings
+
+
+def check_markers(spec, config, after_clarify):
+    """Offene [Annahme:]- und [Offen:]-Marker.
+
+    Vor Clarify sind beide legitim, danach nicht mehr. Deshalb laeuft die
+    Regel nur mit --nach-clarify.
+    """
+    if not after_clarify:
+        return []
+    level = level_for(config, "open_marker")
+    findings = []
+    for story in spec.stories:
+        for number, kind, text in story.markers:
+            findings.append(Finding(
+                "open_marker", level, story.id,
+                "offener Marker [%s: %s]" % (kind, text[:40]), number,
+                "in Clarify (Modus 2) aufloesen"))
+    return findings
+
+
+def check_ids(spec, config):
+    from .spec import valid_id, ID_PREFIXES
+    findings = []
+    schema_level = level_for(config, "id_schema")
+    unique_level = level_for(config, "id_unique")
+    seen = {}
+    for story in spec.stories:
+        if not valid_id(story.id):
+            findings.append(Finding(
+                "id_schema", schema_level, story.id,
+                "ID folgt nicht SF-{Praefix}-{NNN}", story.line,
+                "gueltige Praefixe: " + ", ".join(ID_PREFIXES)))
+        if story.id in seen:
+            findings.append(Finding(
+                "id_unique", unique_level, story.id,
+                "ID schon in Zeile %d vergeben" % seen[story.id], story.line,
+                "eine ID zeigt auf genau eine Anforderung"))
+        else:
+            seen[story.id] = story.line
+    return findings
+
+
+def check_traceability(spec, tasks, config):
+    """AP-07: Task ohne Story, Story ohne Task."""
+    if tasks is None:
+        return []
+    findings = []
+    task_level = level_for(config, "orphan_task")
+    story_level = level_for(config, "orphan_story")
+    known = set(story.id for story in spec.stories)
+    referenced = set()
+    for task_id, number, refs in tasks:
+        valid = [ref for ref in refs if ref in known]
+        referenced.update(valid)
+        if not valid:
+            findings.append(Finding(
+                "orphan_task", task_level, task_id,
+                "kein Verweis auf eine Story dieser Spec", number,
+                "Story-ID im Task ergaenzen (AP-07)"))
+    for story in spec.stories:
+        if story.id not in referenced:
+            findings.append(Finding(
+                "orphan_story", story_level, story.id,
+                "keine Entsprechung in tasks.md", story.line,
+                "Task anlegen oder Story streichen (AP-07)"))
+    return findings
+
+
+def run(spec, tasks, config, after_clarify=False):
+    findings = []
+    findings.extend(check_ids(spec, config))
+    findings.extend(check_ears(spec, config))
+    findings.extend(check_gherkin(spec, config))
+    findings.extend(check_vague(spec, config))
+    findings.extend(check_sophist(spec, config))
+    findings.extend(check_markers(spec, config, after_clarify))
+    findings.extend(check_traceability(spec, tasks, config))
+    return findings

--- a/cli/specforge_check/rules.py
+++ b/cli/specforge_check/rules.py
@@ -16,6 +16,9 @@ im Payload:
   orphan_story      F3  AP-07, references/08-management.md
   nfr_severity      F3  falsch eingestufte NFR-Luecke, Gate G1 NFR-Scan
 
+Die Regel no_stories hat ebenfalls keine konfigurierbare Stufe. Sie steht
+fest auf F4, siehe NO_STORIES_LEVEL.
+
 Die Regel nfr_gap hat keine Default-Stufe. Ihre F-Stufe steht im Marker
 selbst ([NFR-Lücke F4: IRM-01 — ...]), so wie enforcement-engine.md das
 NFR-Luecken-Format festlegt.
@@ -23,6 +26,7 @@ NFR-Luecken-Format festlegt.
 Wer einen anderen Wert braucht, setzt ihn in checks_config, nicht hier.
 """
 
+import os
 import re
 
 # AP-04, Blocklist aus SKILL.md, globale Regel 4. Die Endungen decken die
@@ -72,6 +76,14 @@ NFR_ID_RE = re.compile(r"^([A-Z]{2,5})-(\d{2})\b")
 
 GHERKIN_MINIMUM = 2
 
+# Eine spec.md ohne erkannte Story ist der Fall, in dem der Linter am
+# meisten schadet: er hat nichts geprueft und meldet trotzdem ein Ergebnis.
+# Ein abgeschnittenes Artefakt, ein Pfad auf das falsche Verzeichnis, ein
+# Story-Kopf in eigener Schreibweise sehen dann alle aus wie eine saubere
+# Spec. Die Stufe steht deshalb hier und nicht in checks_config: wer sie
+# herunterkonfigurieren koennte, haette das Loch wieder.
+NO_STORIES_LEVEL = "F4"
+
 
 class Finding(object):
     def __init__(self, check, level, subject, message, line=None,
@@ -95,6 +107,27 @@ def _compiled(mapping):
 VAGUE_RE = _compiled(VAGUE_TERMS)
 SOPHIST_RE = [(label, re.compile(pattern, re.I))
               for label, pattern in sorted(SOPHIST_TERMS.items())]
+
+
+def check_no_stories(spec, config):
+    """Kein Story-Kopf erkannt: der Lauf hat nichts geprueft.
+
+    Leere Datei und Datei mit fremdem Story-Format sind zwei verschiedene
+    Ursachen und bekommen zwei verschiedene Meldungen. Beide sind ein
+    Befund, kein Ergebnis.
+    """
+    if spec.stories:
+        return []
+    if any(line.strip() for line in spec.lines):
+        message = ("kein Story-Kopf im Format '### [SF-XXX-NNN] Titel' "
+                   "gefunden")
+        remedy = ("Story-Koepfe nach docs/spec-format.md schreiben; die "
+                  "Datei hat Inhalt, aber keinen erkennbaren Abschnitt")
+    else:
+        message = "Datei ist leer"
+        remedy = "Pfad pruefen: hier liegt keine ausgefuellte Spezifikation"
+    return [Finding("no_stories", NO_STORIES_LEVEL,
+                    os.path.basename(spec.path), message, None, remedy)]
 
 
 def level_for(config, check):
@@ -282,6 +315,7 @@ def check_nfr_gaps(spec, config, packages):
 
 def run(spec, tasks, config, after_clarify=False, packages=None):
     findings = []
+    findings.extend(check_no_stories(spec, config))
     findings.extend(check_ids(spec, config))
     findings.extend(check_ears(spec, config))
     findings.extend(check_gherkin(spec, config))

--- a/cli/specforge_check/severity.py
+++ b/cli/specforge_check/severity.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""F-Stufen, ihre Gate-Wirkung und der Legacy-Uebersetzer.
+
+Die Tabelle stammt aus references/enforcement/enforcement-engine.md,
+Abschnitt I.2. Sie ist hier einmal abgebildet und sonst nirgends, damit ein
+geaenderter Wert genau eine Stelle im Code hat.
+"""
+
+LEVELS = ("F0", "F1", "F2", "F3", "F4", "F5")
+
+# F-Stufe -> (Gate-Ergebnis, Symbol, Bezeichnung)
+GATE = {
+    "F4": ("FAIL", "❌", "Schwergewichtiger Mangel"),
+    "F3": ("CONDITIONAL", "⚠️", "Gewichtiger Mangel"),
+    "F2": ("WARNING", "⚠️", "Mittelschwerer Mangel"),
+    "F1": ("INFO", "ℹ️", "Geringfuegiger Mangel"),
+    "F0": ("PASS", "✅", "Kein Mangel"),
+    "F5": ("SKIP", "⏭️", "Nicht anwendbar"),
+}
+
+# Reihenfolge der Ausgabe: schwerster Befund zuerst.
+ORDER = ("F4", "F3", "F2", "F1", "F0", "F5")
+
+# Der Eingangs-Uebersetzer fuer alte specforge.json-Dateien ohne
+# severity_model. Er gilt beim Einlesen und sonst nirgends; die Regeln des
+# Checkers vergeben ausschliesslich F-Stufen.
+LEGACY = {
+    "BLOCKER": "F4",
+    "MAJOR": "F3",
+    "MINOR": "F1",
+}
+
+
+def normalise(value):
+    """Macht aus einer Konfigurationsangabe eine F-Stufe.
+
+    Akzeptiert 'F4', 'F 4', True/False (Boolean-Logik der Altprojekte) und
+    die drei Legacy-Werte. Gibt None zurueck, wenn nichts davon passt.
+    """
+    if value is True:
+        return "F4"
+    if value is False:
+        return "F1"
+    if not isinstance(value, str):
+        return None
+    text = value.strip().upper().replace(" ", "")
+    if text in LEVELS:
+        return text
+    return LEGACY.get(text)
+
+
+def rank(level):
+    """Sortierschluessel: kleiner heisst schwerer."""
+    return ORDER.index(level) if level in ORDER else len(ORDER)
+
+
+def worst(levels):
+    """Schwerste Stufe einer Menge von Befunden."""
+    relevant = [level for level in levels if level in ("F4", "F3", "F2", "F1")]
+    if not relevant:
+        return "F0"
+    return sorted(relevant, key=rank)[0]

--- a/cli/specforge_check/spec.py
+++ b/cli/specforge_check/spec.py
@@ -11,7 +11,7 @@ import re
 
 STORY_RE = re.compile(r"^###\s+\[([A-Za-z0-9_-]+)\]\s*(.*)$")
 SECTION_RE = re.compile(r"^##\s+")
-# **Pattern:** Wert und **Pattern**: Wert — beide Formen stehen im Template.
+# **Pattern:** Wert und **Pattern**: Wert, beide Formen stehen im Template.
 FIELD_RE = re.compile(r"^\*\*([^*:]+?)\*\*\s*:\s*(.*)$|^\*\*([^*:]+?):\*\*\s*(.*)$")
 SCENARIO_RE = re.compile(r"^\s*Scenario:\s*(.*)$")
 GHERKIN_STEP_RE = re.compile(r"^\s*(Given|When|Then|And|But)\b", re.I)

--- a/cli/specforge_check/spec.py
+++ b/cli/specforge_check/spec.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""Parser fuer spec.md und tasks.md.
+
+Das Format ist in docs/spec-format.md festgeschrieben. Der Parser haelt sich
+daran und raet nicht: was er nicht sicher erkennt, meldet er nicht als
+erkannt, sondern gar nicht. Ein Checker, der zuviel errät, produziert
+Befunde, die niemand nachvollziehen kann.
+"""
+
+import re
+
+STORY_RE = re.compile(r"^###\s+\[([A-Za-z0-9_-]+)\]\s*(.*)$")
+SECTION_RE = re.compile(r"^##\s+")
+# **Pattern:** Wert und **Pattern**: Wert — beide Formen stehen im Template.
+FIELD_RE = re.compile(r"^\*\*([^*:]+?)\*\*\s*:\s*(.*)$|^\*\*([^*:]+?):\*\*\s*(.*)$")
+SCENARIO_RE = re.compile(r"^\s*Scenario:\s*(.*)$")
+GHERKIN_STEP_RE = re.compile(r"^\s*(Given|When|Then|And|But)\b", re.I)
+ID_RE = re.compile(r"^SF-([A-Z]{3,4})-(\d{3})$")
+TASK_RE = re.compile(r"\bT-(\d{3})\b")
+STORY_REF_RE = re.compile(r"\bSF-[A-Z]{3,4}-\d{3}\b")
+
+MARKER_RE = re.compile(r"\[(Annahme|Offen)\s*:\s*([^\]]*)\]")
+NFR_GAP_RE = re.compile(r"\[NFR-Lücke\s+F(\d)\s*:\s*([^\]]*)\]")
+
+EARS_PATTERNS = ("Ubiquitous", "Event-Driven", "State-Driven", "Optional",
+                 "Unwanted")
+# Praefixe laut spec-template.md, Abschnitt ID-Schema.
+ID_PREFIXES = ("FUNC", "SEC", "AVA", "INT", "AUD", "PER", "USA", "COM",
+               "OPS", "DAT")
+
+
+class Story(object):
+    def __init__(self, ident, title, line):
+        self.id = ident
+        self.title = title
+        self.line = line
+        self.fields = {}
+        self.scenarios = []
+        self.markers = []
+        self.nfr_gaps = []
+        self.lines = []
+
+    @property
+    def pattern(self):
+        return self.fields.get("Pattern")
+
+    def __repr__(self):
+        return "<Story %s, %d Szenarien>" % (self.id, len(self.scenarios))
+
+
+class Spec(object):
+    def __init__(self, path):
+        self.path = path
+        self.stories = []
+        self.lines = []
+
+    @property
+    def text(self):
+        return "\n".join(self.lines)
+
+
+def read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read().split("\n")
+
+
+def parse_spec(path):
+    """Liest eine spec.md und gibt ein Spec-Objekt zurueck."""
+    spec = Spec(path)
+    spec.lines = read(path)
+
+    current = None
+    in_fence = False
+    for number, line in enumerate(spec.lines, 1):
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            if current is not None:
+                current.lines.append((number, line))
+            continue
+
+        head = STORY_RE.match(line)
+        if head:
+            current = Story(head.group(1).strip(), head.group(2).strip(),
+                            number)
+            spec.stories.append(current)
+            continue
+        if SECTION_RE.match(line):
+            current = None
+            continue
+        if current is None:
+            continue
+
+        current.lines.append((number, line))
+
+        field = FIELD_RE.match(line)
+        if field:
+            key = field.group(1) or field.group(3)
+            value = field.group(2) if field.group(1) else field.group(4)
+            current.fields[key.strip()] = value.strip()
+
+        scenario = SCENARIO_RE.match(line)
+        if scenario:
+            current.scenarios.append((number, scenario.group(1).strip()))
+
+        for marker in MARKER_RE.finditer(line):
+            current.markers.append((number, marker.group(1),
+                                    marker.group(2).strip()))
+        for gap in NFR_GAP_RE.finditer(line):
+            current.nfr_gaps.append((number, "F" + gap.group(1),
+                                     gap.group(2).strip()))
+
+    return spec
+
+
+def parse_tasks(path):
+    """Liest eine tasks.md und gibt [(task_id, zeile, [story_ids])] zurueck."""
+    tasks = []
+    for number, line in enumerate(read(path), 1):
+        match = TASK_RE.search(line)
+        if not match:
+            continue
+        refs = STORY_REF_RE.findall(line)
+        tasks.append(("T-" + match.group(1), number, refs))
+    return tasks
+
+
+def valid_id(ident):
+    match = ID_RE.match(ident)
+    if not match:
+        return False
+    return match.group(1) in ID_PREFIXES
+
+
+def known_pattern(value):
+    if not value:
+        return False
+    return value.strip().lower() in [p.lower() for p in EARS_PATTERNS]

--- a/course.html
+++ b/course.html
@@ -1201,7 +1201,7 @@ pre,code{white-space:pre-wrap;word-break:break-word;overflow-x:hidden}
           <h3 class="quiz-question">Wie bewertet SpecForge diese Situation?</h3>
           <div class="quiz-options">
             <button class="quiz-option" data-value="opt-4a" onclick="selectOption(this)">
-              <div class="quiz-option-radio"></div><span>GP-02 Verstoß (BLOCKER) — Code ohne Spec ist verboten</span>
+              <div class="quiz-option-radio"></div><span>GP-02 Verstoß (F4) — Code ohne Spec ist verboten</span>
             </button>
             <button class="quiz-option" data-value="opt-4b" onclick="selectOption(this)">
               <div class="quiz-option-radio"></div><span>Kein Problem — der Code funktioniert ja</span>
@@ -1210,7 +1210,7 @@ pre,code{white-space:pre-wrap;word-break:break-word;overflow-x:hidden}
               <div class="quiz-option-radio"></div><span>AP-01 Implementation Bias — Technik statt Anforderung</span>
             </button>
           </div>
-          <div class="quiz-feedback" data-correct-text="<strong>Genau!</strong> GP-02 'Spec-before-Code' ist eines der wichtigsten Prinzipien: Keine Implementierung ohne Spec-Eintrag. Das ist ein BLOCKER — der Code muss nachspezifiziert werden, egal wie gut er funktioniert." data-incorrect-text="<strong>Nicht ganz.</strong> Egal ob der Code funktioniert — GP-02 sagt: Keine Implementierung ohne Spec-Eintrag. Das ist ein BLOCKER-Verstoß. Der Code muss nachspezifiziert werden."></div>
+          <div class="quiz-feedback" data-correct-text="<strong>Genau!</strong> GP-02 'Spec-before-Code' ist eines der wichtigsten Prinzipien: Keine Implementierung ohne Spec-Eintrag. Das ist ein F4-Befund — der Code muss nachspezifiziert werden, egal wie gut er funktioniert." data-incorrect-text="<strong>Nicht ganz.</strong> Egal ob der Code funktioniert — GP-02 sagt: Keine Implementierung ohne Spec-Eintrag. Das ist ein F4-Verstoß. Der Code muss nachspezifiziert werden."></div>
         </div>
 
         <div class="quiz-question-block" data-correct="opt-5b">

--- a/docs/ci-example.yml
+++ b/docs/ci-example.yml
@@ -4,6 +4,16 @@
 # Der Tag hinter dem @ pinnt die Action auf ein Release dieses Repos. Ohne
 # Pin laeuft die Pruefung gegen den jeweiligen Stand von main, und ein
 # Regelwechsel dort bricht fremde Pipelines ohne Vorwarnung.
+#
+# Achtung: die Composite Action gibt es erst ab dem naechsten Release. Der
+# Tag unten ist der aktuelle Stand der Versionsquelle und wandert mit ihr,
+# das Verzeichnis .github/actions/specforge-check/ liegt in v3.2.0 noch
+# nicht. Bis dahin ruft ein fremdes Repository den Linter ueber einen
+# eigenen Checkout dieses Repos auf:
+#
+#   - uses: actions/checkout@v4
+#     with: { repository: GodModeAI2025/specforge-ai-skill, path: .specforge }
+#   - run: python3 .specforge/cli/specforge check specs/mein-feature
 
 name: Spec-Check
 

--- a/docs/ci-example.yml
+++ b/docs/ci-example.yml
@@ -1,0 +1,27 @@
+# Beispiel-Workflow fuer ein fremdes Repository, das seine Specs mit
+# SpecForge schreibt. Kopieren nach .github/workflows/spec-check.yml.
+#
+# Der Tag hinter dem @ pinnt die Action auf ein Release dieses Repos. Ohne
+# Pin laeuft die Pruefung gegen den jeweiligen Stand von main, und ein
+# Regelwechsel dort bricht fremde Pipelines ohne Vorwarnung.
+
+name: Spec-Check
+
+on:
+  pull_request:
+    paths:
+      - 'specs/**'
+
+jobs:
+  spec:
+    name: specforge check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository auschecken
+        uses: actions/checkout@v4
+
+      - name: Spezifikation pruefen
+        uses: GodModeAI2025/specforge-ai-skill/.github/actions/specforge-check@v3.2.0
+        with:
+          pfad: specs/mein-feature
+          nach-clarify: 'true'

--- a/docs/f-stufen-entscheidung.md
+++ b/docs/f-stufen-entscheidung.md
@@ -11,7 +11,7 @@ Das Repo hatte die Frage an drei Stellen selbst beantwortet, ohne die Folge zu z
 `kritis-nfr.md` führte die alten Werte unter "Legacy-Kompatibilität", `enforcement-engine.md` unter
 "Abwärtskompatibilität", und die SKILL.md nannte das Verhalten ohne `severity_model` ausdrücklich
 Legacy. Dazu kommt der sachliche Grund: die F-Stufen decken sechs Zustände ab, die alten Werte
-drei. F0, F2 und F5 sind über das Mapping nicht erreichbar, werden aber gebraucht — F2 als
+drei. F0, F2 und F5 sind über das Mapping nicht erreichbar, werden aber gebraucht: F2 als
 Pflicht-Task vor Go-Live, F5 als dokumentierter Skip, F0 als Positivbefund im Gate-Ergebnis.
 
 ## Warum das kein Suchen-und-Ersetzen war
@@ -60,7 +60,8 @@ Sache trifft.
 Gate G1 führte "Gherkin-Szenarien ≥2 pro Story" als F4, AP-06 ("Missing Negative") als F3, und die
 Module beriefen sich mal auf das eine, mal auf das andere. Aufgelöst ist das jetzt über eine
 Trennung: die Mindestanzahl von zwei Szenarien ist der Gate-Prüfpunkt und damit F4. AP-06 greift
-eine Stufe darüber — Szenarien sind vorhanden, decken aber nur den Happy Path ab — und bleibt F3.
+eine Stufe darüber, nämlich wenn Szenarien vorhanden sind, aber nur den Happy Path abdecken, und
+bleibt F3.
 
 ## Was bleibt
 

--- a/docs/f-stufen-entscheidung.md
+++ b/docs/f-stufen-entscheidung.md
@@ -1,0 +1,70 @@
+# Ein Schweregrad-Dialekt: F0 bis F5
+
+Bis Version 3.2 liefen zwei Skalen nebeneinander. Die Enforcement Engine, Modus 10 und beide
+Regulatorik-Extensions sprachen F-Stufen, fünf Fachmodule sprachen ausschließlich BLOCKER, MAJOR
+und MINOR, drei mischten. Dieses Dokument hält fest, wie die Umstellung entschieden wurde, damit
+sich einzelne Werte später nachvollziehen lassen, ohne die Diskussion neu zu führen.
+
+## Warum die F-Stufen gewinnen
+
+Das Repo hatte die Frage an drei Stellen selbst beantwortet, ohne die Folge zu ziehen:
+`kritis-nfr.md` führte die alten Werte unter "Legacy-Kompatibilität", `enforcement-engine.md` unter
+"Abwärtskompatibilität", und die SKILL.md nannte das Verhalten ohne `severity_model` ausdrücklich
+Legacy. Dazu kommt der sachliche Grund: die F-Stufen decken sechs Zustände ab, die alten Werte
+drei. F0, F2 und F5 sind über das Mapping nicht erreichbar, werden aber gebraucht — F2 als
+Pflicht-Task vor Go-Live, F5 als dokumentierter Skip, F0 als Positivbefund im Gate-Ergebnis.
+
+## Warum das kein Suchen-und-Ersetzen war
+
+Das Mapping ist verlustbehaftet. BLOCKER, MAJOR und MINOR treffen nur F4, F3 und F1. MAJOR diente
+im Payload als Sammelstufe: es stand für "Gate blockiert bis zur Risiko-Akzeptanz" ebenso wie für
+"das Artefakt gehört in eine eigene Datei". Pauschal auf F3 übersetzt, hätte jedes dieser
+Formalien-Findings eine Risiko-Akzeptanz durch das Leitungsorgan verlangt. Deshalb wurde jeder
+Prüfpunkt einzeln bewertet.
+
+## Die Regel für den Einzelfall
+
+1. Führt ein Gate oder die Anti-Pattern-Tabelle in `enforcement-engine.md` denselben Prüfpunkt,
+   gilt deren Wert. Die Engine ist die normative Quelle, das Modul die Wiederholung.
+2. Sonst die vier Fragen in dieser Reihenfolge: Blockiert der Befund die Phase (F4)? Braucht er
+   eine dokumentierte Risiko-Akzeptanz (F3)? Reicht ein Pflicht-Task vor Go-Live (F2)? Oder ist es
+   eine Empfehlung (F1)?
+3. Profilabhängige Werte in der Notation `F3 (KRITIS: F4)` schreiben, wie sie der
+   Artefakt-Vollständigkeits-Check der Engine schon verwendet.
+
+## Was sich dabei verschoben hat
+
+| Prüfpunkt | vorher | jetzt | Quelle |
+|-----------|--------|-------|--------|
+| Vage Begriffe aus der Blocklist (AP-04) | BLOCKER | F4 | AP-Tabelle, Gate G2 |
+| EARS-Pflicht | MAJOR | F4 | Gate G1 |
+| Gherkin-Minimum ≥2 Szenarien | MAJOR | F4 | Gate G1 |
+| ADR-Pflicht (GP-03) | MAJOR / BLOCKER bei KRITIS | F3 (KRITIS: F4) | Gate G3, profilabhängig |
+| ExecPlan-Pflicht (GP-04) | MAJOR | F2 | Gate G3 |
+| Artefakt als Datei statt inline | MAJOR | F2 | Gate G2, Artefakt-Erwartung |
+| Stale Marker ohne Datum und Owner (GP-06) | MINOR | F2 | Gate G5 |
+| ARCHITECTURE.md nicht aktuell | MINOR | F3 | Gate G5 |
+| Constitution ohne aktive GPs (TM-06) | MINOR | F4 | Gate G0 |
+| Orphan Task, Orphan Spec (AP-07) | MAJOR | F3 | AP-Tabelle |
+| Task ohne Spec-Referenz (AP-05, GP-02) | BLOCKER | F4 | AP-Tabelle |
+| Tech-Debt ohne Eintrag (GP-10) | MINOR, MAJOR bei NFR-Wirkung | F1, F2 bei NFR-Wirkung | Artefakt-Check |
+| ID-Schema, Atomarität | MINOR | F1 | Einzelbewertung |
+
+Vier Prüfpunkte sind dabei strenger geworden, weil die Engine sie höher führte als die
+Modulprosa: TM-06 (Constitution), TM-07 und SFC-06 (ARCHITECTURE.md), FR-04 (Freshness). Sechs
+sind milder geworden, weil MAJOR dort als Sammelstufe stand und ein Pflicht-Task vor Go-Live die
+Sache trifft.
+
+## Ein Widerspruch, der aufgelöst werden musste
+
+Gate G1 führte "Gherkin-Szenarien ≥2 pro Story" als F4, AP-06 ("Missing Negative") als F3, und die
+Module beriefen sich mal auf das eine, mal auf das andere. Aufgelöst ist das jetzt über eine
+Trennung: die Mindestanzahl von zwei Szenarien ist der Gate-Prüfpunkt und damit F4. AP-06 greift
+eine Stufe darüber — Szenarien sind vorhanden, decken aber nur den Happy Path ab — und bleibt F3.
+
+## Was bleibt
+
+Das Legacy-Mapping in `enforcement-engine.md` bleibt bestehen, mit einem Zweck: eine alte
+`specforge.json` ohne `severity_model` einzulesen. Beim Einlesen wird einmal übersetzt, danach
+rechnet die Engine ausschließlich mit F-Stufen. `scripts/check-severity-dialect.py` prüft in der
+CI, dass die alten Werte nirgendwo sonst auftauchen.

--- a/docs/quellen-und-einfluesse.md
+++ b/docs/quellen-und-einfluesse.md
@@ -17,7 +17,7 @@ Zurück zum [README](../README.md).
 | Cynefin Framework (Dave Snowden, 1999) | Phase 0 — Komplexitätseinschätzung vor Modus-Wahl |
 | Impact Mapping (Gojko Adzic, 2012) | Phase 0 — Zielorientierte Scope-Validierung |
 | Socratic Method (Platon/Sokrates) | Clarify-Modus — Sokratische Spezifikationsklärung |
-| Five Whys (Taiichi Ohno, Toyota) | BLOCKER-Analyse in Clarify |
+| Five Whys (Taiichi Ohno, Toyota) | F4-Analyse in Clarify |
 | MECE Principle (Barbara Minto, McKinsey) | Analyze-Modus — Konsistenzprüfung über 5 Dimensionen |
 | Devil's Advocate + Steelmanning | Stakeholder-Simulation — systematische Gegenargumentation |
 | Morphological Box (Fritz Zwicky, 1940er) | Plan-Modus — Systematische Lösungsraum-Exploration |

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -2,7 +2,7 @@
 
 `references/templates/spec-template.md` beschreibt, was in einer Spezifikation stehen muss. Was es
 bisher nicht beschrieb: woran ein Programm die Teile wiedererkennt. Dieses Dokument schließt die
-Lücke. Es ist die Grundlage für `specforge check` und ändert das Template nicht — es liest es
+Lücke. Es ist die Grundlage für `specforge check` und ändert das Template nicht, es liest es
 genauer.
 
 Das Format ist bewusst dasselbe Markdown, das Claude ohnehin erzeugt. Kein Frontmatter-Zwang, kein

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -1,0 +1,85 @@
+# Das maschinenlesbare Format der spec.md
+
+`references/templates/spec-template.md` beschreibt, was in einer Spezifikation stehen muss. Was es
+bisher nicht beschrieb: woran ein Programm die Teile wiedererkennt. Dieses Dokument schließt die
+Lücke. Es ist die Grundlage für `specforge check` und ändert das Template nicht — es liest es
+genauer.
+
+Das Format ist bewusst dasselbe Markdown, das Claude ohnehin erzeugt. Kein Frontmatter-Zwang, kein
+zweites Dateiformat, keine Code-Fences um die Gherkin-Blöcke.
+
+## Story-Kopf
+
+Eine Story beginnt mit einer H3-Überschrift, die mit der ID in eckigen Klammern anfängt:
+
+```markdown
+### [SF-SEC-001] Anmeldung mit zweitem Faktor
+```
+
+Die ID folgt dem Schema `SF-{Präfix}-{NNN}`. Gültige Präfixe stehen in `spec-template.md`,
+Abschnitt ID-Schema: FUNC, SEC, AVA, INT, AUD, PER, USA, COM, OPS, DAT. Drei Ziffern, führende
+Nullen inklusive. Eine Story endet, wo die nächste H3-Überschrift oder eine H2-Überschrift beginnt.
+
+## EARS-Pattern
+
+Innerhalb der Story steht das Pattern als Fettdruck-Feld am Zeilenanfang:
+
+```markdown
+**Pattern:** Event-Driven
+```
+
+Erlaubt sind genau die fünf Werte aus `references/checklists/ears-syntax.md`: Ubiquitous,
+Event-Driven, State-Driven, Optional, Unwanted. Groß- und Kleinschreibung ist egal, der Bindestrich
+nicht.
+
+Dieselbe Schreibweise gilt für die übrigen Kopffelder der Story (`**Typ**:`, `**Priorität**:`,
+`**REQ-ID**:`). Der Doppelpunkt darf innerhalb oder außerhalb der Fettung stehen, beide Formen
+kommen im Template vor.
+
+## Gherkin-Szenarien
+
+Ein Szenario beginnt mit `Scenario:` am Zeilenanfang, ohne Code-Fence, und läuft bis zum nächsten
+`Scenario:`, zur nächsten Überschrift oder zum Ende der Story. Die Zeilen dazwischen beginnen mit
+Given, When, Then, And oder But.
+
+```markdown
+Scenario: Anmeldung mit gültigem zweitem Faktor
+  Given ein Konto mit aktivierter Zwei-Faktor-Authentisierung
+  When der Nutzer einen gültigen TOTP-Code eingibt
+  Then gewährt der Auth-Service Zugriff
+```
+
+Zwei Szenarien je Story sind Pflicht, eines davon ein Fehlerfall. Die Zählung prüft die Anzahl,
+nicht den Inhalt: ob das zweite Szenario wirklich einen Fehlerfall beschreibt, entscheidet weiterhin
+ein Mensch oder die Session.
+
+## Marker
+
+Drei Marker sind maschinenlesbar und stehen irgendwo im Story-Text:
+
+| Marker | Bedeutung | Auflösung |
+|--------|-----------|-----------|
+| `[Annahme: ...]` | unbestätigte Voraussetzung | Clarify (Modus 2) |
+| `[Offen: ...]` | fehlende Information, Story trotzdem erzeugt | Clarify (Modus 2) |
+| `[NFR-Lücke F{n}: ...]` | fehlender NFR mit F-Stufe | Plan oder Analyze |
+
+Nach Clarify dürfen `[Annahme: ...]` und `[Offen: ...]` nicht mehr offenstehen. `specforge check`
+prüft das nur mit `--nach-clarify`, weil eine Spec vor Clarify beide legitim trägt.
+
+## Verweis auf Tasks
+
+`tasks.md` referenziert Stories über die Story-ID im Klartext, in beliebiger Zeile des Tasks:
+
+```markdown
+- [ ] T-004 Auth-Service um TOTP-Prüfung erweitern (SF-SEC-001)
+```
+
+Ein Task beginnt mit einer Zeile, die eine Task-ID im Format `T-NNN` enthält. Ein Task ohne
+Story-ID ist ein Orphan Task (AP-07), eine Story ohne Task ein Orphan Spec.
+
+## Was der Checker nicht liest
+
+Alles, was Bedeutung statt Struktur ist. Ob die EARS-Formulierung inhaltlich zum genannten Pattern
+passt, ob ein NFR-Zielwert realistisch ist, ob die STRIDE-Bewertung vollständig gedacht wurde: das
+bleibt in der Session. Der Checker prüft, was ohne Modell entscheidbar ist, und meldet den Rest
+nicht als bestanden, sondern gar nicht.

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -77,6 +77,18 @@ prüft das nur mit `--nach-clarify`, weil eine Spec vor Clarify beide legitim tr
 Ein Task beginnt mit einer Zeile, die eine Task-ID im Format `T-NNN` enthält. Ein Task ohne
 Story-ID ist ein Orphan Task (AP-07), eine Story ohne Task ein Orphan Spec.
 
+## Wenn nichts erkannt wird
+
+Findet der Checker in einer `spec.md` keinen Story-Kopf im Format oben, meldet er das als eigenen
+Befund `no_stories` in F4, und der Lauf endet mit Exit 1. Das gilt für die leere Datei ebenso wie
+für eine gefüllte, deren Überschriften vom Format abweichen. Der Grund steht im nächsten Abschnitt:
+was der Checker nicht sicher erkennt, meldet er nicht als bestanden. Ein Lauf über null Stories mit
+dem Ergebnis PASS wäre genau diese Aussage, und ein abgeschnittenes Artefakt oder ein Pfad auf das
+falsche Verzeichnis käme damit durch jedes Gate.
+
+Die F-Stufe dieses Befunds ist nicht über `checks_config` konfigurierbar. Sie steht im Code, weil
+eine herunterkonfigurierbare Stufe die Lücke wieder öffnet.
+
 ## Was der Checker nicht liest
 
 Alles, was Bedeutung statt Struktur ist. Ob die EARS-Formulierung inhaltlich zum genannten Pattern

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,53 @@
+# Eval-Suite
+
+Sechs Golden Specs und ihre erwarteten Befunde. Sie sind zugleich die ersten echten
+Spezifikationen im Repo: bis hierher lagen nur Templates und Eingabe-Prompts, an denen sich kein
+Ergebnis messen ließ.
+
+## Aufbau
+
+```
+evals/golden/<fall>/
+  spec.md          die Spezifikation
+  tasks.md         optional, für die Traceability-Prüfung
+  specforge.json   optional, für Profil, Perspektive und checks_config
+  expected.json    Exit-Code und die erwarteten Befunde
+```
+
+`expected.json` nennt neben der Erwartung auch, was der Fall belegt. Ein Golden-Fall, dessen
+Zweck sich nicht in einem Satz sagen lässt, prüft meist nichts.
+
+## Ausführen
+
+```bash
+python3 evals/run_static.py              # alle Fälle
+python3 evals/run_static.py 04           # nur passende Fälle
+python3 evals/run_static.py --ausgabe    # mit der vollen Gate-Ausgabe
+```
+
+Exit 0, wenn alle Fälle bestehen. Die CI fährt das Skript bei jedem Lauf.
+
+## Die Fälle
+
+| Fall | Perspektive | Exit | Belegt |
+|------|-------------|------|--------|
+| 01-kritis-valide | — | 0 | Der Forward-Path läuft ohne Befund durch |
+| 02-gherkin-fehlt | — | 1 | Gherkin-Minimum ist F4, nicht F3 |
+| 03-dora-regulated-ohne-irm01 | regulated_entity | 1 | Fehlender IRM-01-NFR blockiert das Gate |
+| 04-dora-advisory-ohne-irm01 | advisory | 0 | Dieselbe Lücke, F2 statt F4, Gate passierbar |
+| 05-orphan-task | — | 2 | AP-07 ist F3: passierbar mit Risiko-Akzeptanz |
+| 06-dora-falsche-f-stufe | advisory | 1 | Eine zu hart eingestufte Lücke ist selbst ein Befund |
+
+Die Fälle 03 und 04 sind das Paar, an dem die Schweregrad-Vereinheitlichung hängt. Das frühere,
+dreistufige Vokabular konnte den Unterschied nicht abbilden: seine mittlere Stufe übersetzt sich
+in beiden Fällen zu F3 und hätte damit auch dem Beratungsprojekt eine Risiko-Akzeptanz durch das
+Leitungsorgan abverlangt. Hergeleitet ist das in
+[../docs/f-stufen-entscheidung.md](../docs/f-stufen-entscheidung.md).
+
+## Was hier nicht steht
+
+Eine Ebene 2, die dieselben Fälle durch die Claude-API schickt und die Gate-Ausgabe der Session
+mit `expected.json` vergleicht. Das wäre der Beleg, dass Skill-Prosa und Linter dasselbe sagen.
+Sie fehlt bewusst: ein Lauf gegen ein Sprachmodell ist nicht reproduzierbar, kostet Budget und
+braucht ein Secret. Er gehört in einen eigenen Workflow, nicht in die Pipeline, die bei jedem
+Push läuft.

--- a/evals/README.md
+++ b/evals/README.md
@@ -31,11 +31,11 @@ Exit 0, wenn alle Fälle bestehen. Die CI fährt das Skript bei jedem Lauf.
 
 | Fall | Perspektive | Exit | Belegt |
 |------|-------------|------|--------|
-| 01-kritis-valide | — | 0 | Der Forward-Path läuft ohne Befund durch |
-| 02-gherkin-fehlt | — | 1 | Gherkin-Minimum ist F4, nicht F3 |
+| 01-kritis-valide | keine | 0 | Der Forward-Path läuft ohne Befund durch |
+| 02-gherkin-fehlt | keine | 1 | Gherkin-Minimum ist F4, nicht F3 |
 | 03-dora-regulated-ohne-irm01 | regulated_entity | 1 | Fehlender IRM-01-NFR blockiert das Gate |
 | 04-dora-advisory-ohne-irm01 | advisory | 0 | Dieselbe Lücke, F2 statt F4, Gate passierbar |
-| 05-orphan-task | — | 2 | AP-07 ist F3: passierbar mit Risiko-Akzeptanz |
+| 05-orphan-task | keine | 2 | AP-07 ist F3: passierbar mit Risiko-Akzeptanz |
 | 06-dora-falsche-f-stufe | advisory | 1 | Eine zu hart eingestufte Lücke ist selbst ein Befund |
 
 Die Fälle 03 und 04 sind das Paar, an dem die Schweregrad-Vereinheitlichung hängt. Das frühere,

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
 # Eval-Suite
 
-Sechs Golden Specs und ihre erwarteten Befunde. Sie sind zugleich die ersten echten
+Sieben Golden Specs und ihre erwarteten Befunde. Sie sind zugleich die ersten echten
 Spezifikationen im Repo: bis hierher lagen nur Templates und Eingabe-Prompts, an denen sich kein
 Ergebnis messen ließ.
 
@@ -37,6 +37,7 @@ Exit 0, wenn alle Fälle bestehen. Die CI fährt das Skript bei jedem Lauf.
 | 04-dora-advisory-ohne-irm01 | advisory | 0 | Dieselbe Lücke, F2 statt F4, Gate passierbar |
 | 05-orphan-task | keine | 2 | AP-07 ist F3: passierbar mit Risiko-Akzeptanz |
 | 06-dora-falsche-f-stufe | advisory | 1 | Eine zu hart eingestufte Lücke ist selbst ein Befund |
+| 07-spec-ohne-story | keine | 1 | Ein Lauf ohne erkannte Story ist kein bestandener Lauf |
 
 Die Fälle 03 und 04 sind das Paar, an dem die Schweregrad-Vereinheitlichung hängt. Das frühere,
 dreistufige Vokabular konnte den Unterschied nicht abbilden: seine mittlere Stufe übersetzt sich

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
 # Eval-Suite
 
-Sieben Golden Specs und ihre erwarteten Befunde. Sie sind zugleich die ersten echten
+Acht Golden Specs und ihre erwarteten Befunde. Sie sind zugleich die ersten echten
 Spezifikationen im Repo: bis hierher lagen nur Templates und Eingabe-Prompts, an denen sich kein
 Ergebnis messen ließ.
 
@@ -33,17 +33,35 @@ Exit 0, wenn alle Fälle bestehen. Die CI fährt das Skript bei jedem Lauf.
 |------|-------------|------|--------|
 | 01-kritis-valide | keine | 0 | Der Forward-Path läuft ohne Befund durch |
 | 02-gherkin-fehlt | keine | 1 | Gherkin-Minimum ist F4, nicht F3 |
-| 03-dora-regulated-ohne-irm01 | regulated_entity | 1 | Fehlender IRM-01-NFR blockiert das Gate |
-| 04-dora-advisory-ohne-irm01 | advisory | 0 | Dieselbe Lücke, F2 statt F4, Gate passierbar |
+| 03-dora-regulated-ohne-irm01 | regulated_entity | 1 | F4 ist für diese Perspektive die richtige Stufe |
+| 04-dora-advisory-ohne-irm01 | advisory | 0 | F2 passt zur Perspektive: WARNING statt Risiko-Akzeptanz |
 | 05-orphan-task | keine | 2 | AP-07 ist F3: passierbar mit Risiko-Akzeptanz |
-| 06-dora-falsche-f-stufe | advisory | 1 | Eine zu hart eingestufte Lücke ist selbst ein Befund |
+| 06-dora-falsche-f-stufe | advisory | 1 | Dieselbe Spec wie 03, andere Perspektive, ein Befund mehr |
 | 07-spec-ohne-story | keine | 1 | Ein Lauf ohne erkannte Story ist kein bestandener Lauf |
+| 08-dora-luecke-undokumentiert | regulated_entity | 0 | Grenze: eine nicht markierte Lücke sieht der Linter nicht |
 
-Die Fälle 03 und 04 sind das Paar, an dem die Schweregrad-Vereinheitlichung hängt. Das frühere,
-dreistufige Vokabular konnte den Unterschied nicht abbilden: seine mittlere Stufe übersetzt sich
-in beiden Fällen zu F3 und hätte damit auch dem Beratungsprojekt eine Risiko-Akzeptanz durch das
-Leitungsorgan abverlangt. Hergeleitet ist das in
+## Das Perspektiven-Paar
+
+Die Fälle 03 und 06 sind das Paar, an dem die F-Stufen-Zuordnung der Extension hängt: die
+`spec.md` ist in beiden Byte für Byte dieselbe, die `specforge.json` unterscheidet sich in einem
+einzigen Feld, der Perspektive. Für `regulated_entity` ist die F4-Einstufung der Lücke richtig
+und es bleibt beim `nfr_gap` (Fall 03); für `advisory` sieht `@dora` F2 vor, und derselbe Marker
+erzeugt zusätzlich den Befund `nfr_severity` (Fall 06). Das ist der einzige Unterschied, den die
+Perspektive im Linter macht, und damit der Beleg dafür, dass die Perspektiven-Spalten des
+Manifests wirken.
+
+Fall 04 gehört nicht zu diesem Paar. Er zeigt die zur Perspektive passende, mildere
+Selbsteinstufung: F2 ergibt WARNING und einen Pflicht-Task vor Go-Live statt einer
+Risiko-Akzeptanz durch das Leitungsorgan. Genau diesen Unterschied konnte das frühere,
+dreistufige Vokabular nicht abbilden, dessen mittlere Stufe sich in beiden Fällen zu F3
+übersetzt. Hergeleitet ist das in
 [../docs/f-stufen-entscheidung.md](../docs/f-stufen-entscheidung.md).
+
+Was der Linter dabei tut und was nicht: Er liest die F-Stufe, die der Autor in den Marker
+`[NFR-Lücke F{n}: ...]` geschrieben hat, und vergleicht sie mit der F-Stufen-Zuordnung der
+aktiven Extension. Er leitet die Stufe nicht aus der Perspektive ab, und er bemerkt keine
+Anforderung, die niemand als fehlend markiert hat. Fall 08 hält das fest: dieselbe Spec ohne
+Marker läuft mit PASS durch. Der NFR-Scan gegen die Checkliste bleibt Sache der Session.
 
 ## Was hier nicht steht
 

--- a/evals/golden/01-kritis-valide/expected.json
+++ b/evals/golden/01-kritis-valide/expected.json
@@ -1,0 +1,7 @@
+{
+  "beschreibung": "Vollstaendige KRITIS-Spec mit zwei Stories und passender tasks.md. Gate G1 und die Traceability-Pruefung bleiben ohne Befund.",
+  "belegt": "Der Forward-Path laesst sich ohne Befund durchlaufen. Ohne diesen Fall wuerde die Suite nur zeigen, dass der Checker etwas findet, nicht dass er das Richtige findet.",
+  "exit_code": 0,
+  "ergebnis": "PASS",
+  "befunde": []
+}

--- a/evals/golden/01-kritis-valide/spec.md
+++ b/evals/golden/01-kritis-valide/spec.md
@@ -92,7 +92,7 @@ Scenario: Fünf Fehlversuche hintereinander
 - **Verification Command**: `pytest tests/test_totp.py -k SF_SEC_001`
 
 #### KRITIS-NFRs & Governance
-**ITIL/CMDB Impact:** High — betroffen sind Auth-Service und Leitsystem-Gateway
+**ITIL/CMDB Impact:** High (betroffen: Auth-Service und Leitsystem-Gateway)
 - SEC-01 Authentisierung: TOTP nach RFC 6238, Geheimnis im HSM
 - AUD-01 Protokollierung: Konto, Zeitpunkt, Quell-IP, Ergebnis je Versuch
 
@@ -148,12 +148,12 @@ Scenario: Sitzung endet nach 15 Minuten ohne Auth-Service
 - **Verification Command**: `pytest tests/test_session.py -k SF_AVA_001`
 
 #### KRITIS-NFRs & Governance
-**ITIL/CMDB Impact:** Medium — betroffen ist das Leitsystem-Gateway
+**ITIL/CMDB Impact:** Medium (betroffen: Leitsystem-Gateway)
 - AVA-02 Wiederanlauf: RTO 15 Minuten für den Auth-Pfad
 
 #### STRIDE-Bewertung
-[Nicht security-kritisch im Sinne der Zugangsentscheidung — die Sitzung wurde bereits mit zweitem
-Faktor erzeugt. Elevation of Privilege ausgeschlossen, da im Zustand "degraded" keine neuen
+[Nicht security-kritisch im Sinne der Zugangsentscheidung, da die Sitzung bereits mit zweitem
+Faktor erzeugt wurde. Elevation of Privilege ausgeschlossen, da im Zustand "degraded" keine neuen
 Berechtigungen vergeben werden.]
 
 #### Abhängigkeiten

--- a/evals/golden/01-kritis-valide/spec.md
+++ b/evals/golden/01-kritis-valide/spec.md
@@ -1,0 +1,230 @@
+# Feature-Spezifikation: Fernzugriff auf das Leitsystem-Gateway
+
+**ID:** SF-GATEWAY
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Autor:** Requirements Engineering
+**Erstellt:** 2026-09-04
+**Letzte Änderung:** 2026-09-04
+**Constitution-Ref:** constitution.md v1
+**Profil:** kritis
+
+---
+
+## 1. Zusammenfassung (BLUF + Pyramid Principle)
+
+Betriebsführer eines Verteilnetzbetreibers erreichen das Leitsystem-Gateway künftig auch von
+außerhalb des Betriebsgeländes, ohne dass ein Zugang ohne zweiten Faktor entsteht.
+
+Drei Stützen: der Fernzugriff verkürzt die Zeit bis zum Eingriff bei einer Störung; die
+Zwei-Faktor-Pflicht hält die Anforderung aus dem IT-Sicherheitskatalog ein; jeder Zugriff
+hinterlässt einen Audit-Eintrag, der über die gesetzliche Aufbewahrungsfrist erhalten bleibt.
+
+## 2. Kontext & Problemstellung
+
+Heute ist das Leitsystem-Gateway nur aus dem Betriebsnetz erreichbar. Bei einer Störung außerhalb
+der Regelarbeitszeit muss ein Betriebsführer erst anfahren. Ohne Änderung bleibt die Zeit bis zum
+Eingriff an die Fahrzeit gebunden.
+
+## 3. Scope
+
+### In Scope
+- Anmeldung am Leitsystem-Gateway über das Internet mit zweitem Faktor
+- Aufrechterhaltung bestehender Sitzungen bei Ausfall des Auth-Service
+- Audit-Eintrag je Anmeldeversuch
+
+### Out of Scope
+- Steuerbefehle über den Fernzugriff. Lesen ja, Schalten nein.
+- Zugriff für externe Dienstleister
+
+### Annahmen
+- [Annahme: Der Auth-Service läuft in derselben Sicherheitszone wie das Gateway]
+
+## 4. Stakeholder
+
+| Rolle | Interesse | Einfluss |
+|-------|----------|---------|
+| Betriebsführer | Eingriff ohne Anfahrt | Hoch |
+| Informationssicherheitsbeauftragter | Einhaltung des IT-Sicherheitskatalogs | Hoch |
+| Netzleitstelle | Nachvollziehbarkeit jedes Zugriffs | Mittel |
+
+## 5. User Stories & Requirements
+
+### [SF-SEC-001] Anmeldung mit zweitem Faktor
+
+**Typ**: User Story
+**Priorität**: MoSCoW: Must
+**REQ-ID**: [REQ-001]
+**Spec-First Steps**: [1,2,3,4,6,8]
+
+#### Story
+Als Betriebsführer möchte ich mich von außerhalb des Betriebsgeländes am Leitsystem-Gateway
+anmelden, damit ich eine Störung ohne Anfahrt bewerten kann.
+
+#### EARS-Requirement
+**Pattern:** Event-Driven
+Wenn ein Betriebsführer sich am Leitsystem-Gateway anmeldet, dann fordert der Auth-Service einen
+TOTP-Code nach RFC 6238 an und gibt den Zugang erst nach dessen Prüfung frei.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Anmeldung mit gültigem TOTP-Code
+  Given ein Konto mit hinterlegtem TOTP-Geheimnis
+  When der Betriebsführer einen zum aktuellen Zeitfenster passenden Code eingibt
+  Then gewährt der Auth-Service Zugriff auf das Leitsystem-Gateway
+  And schreibt einen Audit-Eintrag mit Konto, Zeitpunkt und Quell-IP
+
+Scenario: Anmeldung mit abgelaufenem TOTP-Code
+  Given ein Konto mit hinterlegtem TOTP-Geheimnis
+  When der Betriebsführer einen Code aus einem vergangenen Zeitfenster eingibt
+  Then verweigert der Auth-Service den Zugriff
+  And schreibt einen Audit-Eintrag mit dem Ablehnungsgrund
+
+Scenario: Fünf Fehlversuche hintereinander
+  Given ein Konto mit vier fehlgeschlagenen Anmeldeversuchen in den letzten 15 Minuten
+  When ein fünfter Versuch fehlschlägt
+  Then sperrt der Auth-Service das Konto für 30 Minuten
+  And benachrichtigt die Netzleitstelle
+
+#### Execution Context (Für GSD & TaskPulse)
+- **Files/Components affected**: auth-service/totp.py, gateway/session.py
+- **Execution Action**: TOTP-Prüfung vor der Sitzungserzeugung einhängen
+- **Verification Command**: `pytest tests/test_totp.py -k SF_SEC_001`
+
+#### KRITIS-NFRs & Governance
+**ITIL/CMDB Impact:** High — betroffen sind Auth-Service und Leitsystem-Gateway
+- SEC-01 Authentisierung: TOTP nach RFC 6238, Geheimnis im HSM
+- AUD-01 Protokollierung: Konto, Zeitpunkt, Quell-IP, Ergebnis je Versuch
+
+#### STRIDE-Bewertung
+- **Spoofing:** Zweiter Faktor verhindert die Übernahme mit gestohlenem Kennwort
+- **Tampering:** TLS 1.3 zwischen Client und Gateway
+- **Repudiation:** Audit-Eintrag je Versuch, Aufbewahrung 24 Monate
+- **Information Disclosure:** Kein Klartext-Geheimnis in Logs
+- **Denial of Service:** Sperre nach fünf Fehlversuchen begrenzt Rateversuche
+- **Elevation of Privilege:** Der Fernzugriff vergibt keine Schaltberechtigung
+
+#### Abhängigkeiten
+- Blockiert: SF-AVA-001
+
+#### GP-Compliance
+- GP-02 erfüllt: Story vor Implementierung
+- GP-05 erfüllt: Test referenziert Invariante INV-03 aus ARCHITECTURE.md
+
+---
+
+### [SF-AVA-001] Sitzungen überdauern einen Ausfall des Auth-Service
+
+**Typ**: Technical Story
+**Priorität**: MoSCoW: Must
+**REQ-ID**: [REQ-002]
+**Spec-First Steps**: [1,4,6,8]
+
+#### Story
+Als Betriebsführer möchte ich, dass eine laufende Sitzung einen kurzen Ausfall des Auth-Service
+übersteht, damit ein Wartungsfenster keine Störungsbearbeitung abbricht.
+
+#### EARS-Requirement
+**Pattern:** State-Driven
+Solange der Auth-Service nicht antwortet, hält das Leitsystem-Gateway bestehende Sitzungen für
+höchstens 15 Minuten aufrecht.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Sitzung überdauert einen Ausfall von 10 Minuten
+  Given eine aktive Sitzung am Leitsystem-Gateway
+  When der Auth-Service 10 Minuten lang nicht antwortet
+  Then bleibt die Sitzung gültig
+  And das Gateway zeigt einen Hinweis auf den eingeschränkten Betrieb
+
+Scenario: Sitzung endet nach 15 Minuten ohne Auth-Service
+  Given eine aktive Sitzung am Leitsystem-Gateway
+  When der Auth-Service 16 Minuten lang nicht antwortet
+  Then beendet das Gateway die Sitzung und verlangt eine Neuanmeldung
+
+#### Execution Context (Für GSD & TaskPulse)
+- **Files/Components affected**: gateway/session.py
+- **Execution Action**: Sitzungs-Timeout auf 15 Minuten setzen, Zustand "degraded" einführen
+- **Verification Command**: `pytest tests/test_session.py -k SF_AVA_001`
+
+#### KRITIS-NFRs & Governance
+**ITIL/CMDB Impact:** Medium — betroffen ist das Leitsystem-Gateway
+- AVA-02 Wiederanlauf: RTO 15 Minuten für den Auth-Pfad
+
+#### STRIDE-Bewertung
+[Nicht security-kritisch im Sinne der Zugangsentscheidung — die Sitzung wurde bereits mit zweitem
+Faktor erzeugt. Elevation of Privilege ausgeschlossen, da im Zustand "degraded" keine neuen
+Berechtigungen vergeben werden.]
+
+#### Abhängigkeiten
+- Blockiert durch: SF-SEC-001
+
+#### GP-Compliance
+- GP-02 erfüllt
+- GP-10 nicht betroffen
+
+---
+
+## 6. Nicht-funktionale Anforderungen (NFRs)
+
+### Performance
+| Metrik | Zielwert | Messmethode |
+|--------|---------|-------------|
+| Anmeldedauer p95 | ≤ 800 ms | Lasttest mit 50 gleichzeitigen Anmeldungen |
+
+### Verfügbarkeit
+| Metrik | Zielwert |
+|--------|---------|
+| Uptime | 99,5 % im Monatsmittel |
+| RTO | 15 Minuten |
+| RPO | 0 (keine persistenten Sitzungsdaten) |
+
+### Sicherheit
+Zweiter Faktor nach RFC 6238, TLS 1.3, TOTP-Geheimnis im HSM. STRIDE je Story dokumentiert.
+
+### Compliance
+IT-Sicherheitskatalog nach § 11 Abs. 1a EnWG, Abschnitt Zugriffskontrolle. NIS2: Artikel 21
+Absatz 2 Buchstabe i (Multi-Faktor-Authentisierung).
+
+## 7. Fachliches Datenmodell
+
+- **Bounded Context:** Zugang zum Leitsystem
+- **Entities:** Konto, Sitzung
+- **Value Objects:** TOTP-Geheimnis, Zeitfenster
+- **Aggregates:** Konto mit seinen Sitzungen; Invariante: höchstens drei aktive Sitzungen
+- **Domain Events:** ZugangGewährt, ZugangVerweigert, KontoGesperrt
+- **Datenklassifizierung:** Konto-Kennung ist PII, TOTP-Geheimnis ist Geheimnis
+
+## 8. Systemgrenzen & Schnittstellen
+
+Rein: HTTPS vom Browser des Betriebsführers. Raus: Audit-Einträge an das SIEM per Syslog.
+Das Leitsystem selbst bleibt hinter dem Gateway und ist nicht direkt erreichbar.
+
+## 9. Clarifications
+
+| # | Frage-Ref | Antwort | Datum | Auswirkung auf |
+|---|-----------|---------|-------|----------------|
+| C-001 | SF-SEC-001 Verfahren | TOTP nach RFC 6238, kein SMS-Verfahren | 2026-09-04 | plan.md, STRIDE |
+| C-002 | SF-AVA-001 Frist | 15 Minuten, abgeleitet aus RTO | 2026-09-04 | NFR AVA-02 |
+
+## 10. Review & Acceptance Checklist
+
+- [x] Alle User Stories haben EARS-Formulierung
+- [x] Jede Story hat ≥2 Gherkin-Szenarien
+- [x] Execution Context (Action & Verify Command) ist für GSD/Agents definiert
+- [x] REQ-IDs für MissionForge Task-Generierung vergeben
+- [x] NFR-Kategorien vollständig geprüft
+- [x] STRIDE für security-relevante Stories durchgeführt
+- [x] Keine vagen Begriffe ohne Quantifizierung
+- [x] Keine offenen F4-Fragen
+- [x] Constitution-Compliance geprüft
+- [x] GP-Compliance pro Story dokumentiert
+- [x] Abhängigkeiten zwischen Stories dokumentiert
+- [x] Systemgrenzen explizit definiert
+
+## 11. Übersichtstabelle
+
+| ID | Titel | Typ | Priorität | EARS | Gherkin | STRIDE | NFR | GP |
+|----|-------|-----|-----------|------|---------|--------|-----|-----|
+| SF-SEC-001 | Anmeldung mit zweitem Faktor | US | Must | ✅ | 3 | ✅ | 2 | 02,05 |
+| SF-AVA-001 | Sitzungen überdauern Ausfall | TS | Must | ✅ | 2 | n.a. | 1 | 02 |

--- a/evals/golden/01-kritis-valide/specforge.json
+++ b/evals/golden/01-kritis-valide/specforge.json
@@ -1,0 +1,15 @@
+{
+  "profile": "kritis",
+  "perspective": null,
+  "severity_model": {
+    "F4": "FAIL", "F3": "CONDITIONAL", "F2": "WARNING",
+    "F1": "INFO", "F0": "PASS", "F5": "SKIP"
+  },
+  "checks_config": {
+    "G1": {
+      "ears_coverage": { "severity": "F4" },
+      "gherkin_minimum": { "severity": "F4" }
+    }
+  },
+  "audit": true
+}

--- a/evals/golden/01-kritis-valide/tasks.md
+++ b/evals/golden/01-kritis-valide/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Fernzugriff auf das Leitsystem-Gateway
 
-- [ ] T-001 [P] TOTP-Prüfung im Auth-Service umsetzen (SF-SEC-001) — Spec-First Steps 1,2,3
-- [ ] T-002 Audit-Eintrag je Anmeldeversuch an das SIEM senden (SF-SEC-001) — Steps 4,6
-- [ ] T-003 Kontosperre nach fünf Fehlversuchen (SF-SEC-001) — Steps 4,6
-- [ ] T-004 Sitzungszustand "degraded" im Gateway einführen (SF-AVA-001) — Steps 1,4,6
+- [ ] T-001 [P] TOTP-Prüfung im Auth-Service umsetzen (SF-SEC-001, Spec-First Steps 1,2,3)
+- [ ] T-002 Audit-Eintrag je Anmeldeversuch an das SIEM senden (SF-SEC-001, Steps 4,6)
+- [ ] T-003 Kontosperre nach fünf Fehlversuchen (SF-SEC-001, Steps 4,6)
+- [ ] T-004 Sitzungszustand "degraded" im Gateway einführen (SF-AVA-001, Steps 1,4,6)

--- a/evals/golden/01-kritis-valide/tasks.md
+++ b/evals/golden/01-kritis-valide/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: Fernzugriff auf das Leitsystem-Gateway
+
+- [ ] T-001 [P] TOTP-Prüfung im Auth-Service umsetzen (SF-SEC-001) — Spec-First Steps 1,2,3
+- [ ] T-002 Audit-Eintrag je Anmeldeversuch an das SIEM senden (SF-SEC-001) — Steps 4,6
+- [ ] T-003 Kontosperre nach fünf Fehlversuchen (SF-SEC-001) — Steps 4,6
+- [ ] T-004 Sitzungszustand "degraded" im Gateway einführen (SF-AVA-001) — Steps 1,4,6

--- a/evals/golden/02-gherkin-fehlt/expected.json
+++ b/evals/golden/02-gherkin-fehlt/expected.json
@@ -1,0 +1,13 @@
+{
+  "beschreibung": "Eine Story mit einem einzigen Szenario. Gate G1 blockiert.",
+  "belegt": "Das Gherkin-Minimum ist F4 und nicht F3. Vor der Vereinheitlichung fuehrten vier Module dazu die mittlere Stufe des alten Vokabulars, die sich zu F3 uebersetzt.",
+  "exit_code": 1,
+  "ergebnis": "FAIL",
+  "befunde": [
+    {
+      "check": "gherkin_minimum",
+      "severity": "F4",
+      "subject": "SF-OPS-001"
+    }
+  ]
+}

--- a/evals/golden/02-gherkin-fehlt/spec.md
+++ b/evals/golden/02-gherkin-fehlt/spec.md
@@ -1,0 +1,29 @@
+# Feature-Spezifikation: Störungsmeldung an die Netzleitstelle
+
+**ID:** SF-MELDUNG
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** standard
+
+## 5. User Stories & Requirements
+
+### [SF-OPS-001] Störungsmeldung absetzen
+
+**Typ**: User Story
+**Priorität**: MoSCoW: Must
+
+#### Story
+Als Betriebsführer möchte ich eine Störung im Meldeportal erfassen, damit die Netzleitstelle den
+Vorgang ohne Telefonat übernimmt.
+
+#### EARS-Requirement
+**Pattern:** Event-Driven
+Wenn ein Betriebsführer eine Störung erfasst, dann übermittelt das Meldeportal den Vorgang
+innerhalb von 60 Sekunden an die Netzleitstelle.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Störungsmeldung erreicht die Netzleitstelle
+  Given ein angemeldeter Betriebsführer
+  When er eine Störung mit Anlagenkennung erfasst
+  Then liegt der Vorgang binnen 60 Sekunden in der Netzleitstelle vor

--- a/evals/golden/03-dora-regulated-ohne-irm01/expected.json
+++ b/evals/golden/03-dora-regulated-ohne-irm01/expected.json
@@ -1,0 +1,13 @@
+{
+  "beschreibung": "Finanzunternehmen ohne IKT-Risikomanagement-Framework. Perspektive regulated_entity.",
+  "belegt": "Dieselbe Luecke wie in Fall 04, andere Perspektive, andere Stufe. Fuer regulated_entity fuehrt die F-Stufen-Tabelle von @dora F4, das Gate blockiert.",
+  "exit_code": 1,
+  "ergebnis": "FAIL",
+  "befunde": [
+    {
+      "check": "nfr_gap",
+      "severity": "F4",
+      "subject": "IRM-01"
+    }
+  ]
+}

--- a/evals/golden/03-dora-regulated-ohne-irm01/expected.json
+++ b/evals/golden/03-dora-regulated-ohne-irm01/expected.json
@@ -1,6 +1,6 @@
 {
-  "beschreibung": "Finanzunternehmen ohne IKT-Risikomanagement-Framework. Perspektive regulated_entity.",
-  "belegt": "Dieselbe Luecke wie in Fall 04, andere Perspektive, andere Stufe. Fuer regulated_entity fuehrt die F-Stufen-Tabelle von @dora F4, das Gate blockiert.",
+  "beschreibung": "Finanzunternehmen ohne IKT-Risikomanagement-Framework, als F4 eingestuft. Perspektive regulated_entity.",
+  "belegt": "Die eine Haelfte des Perspektiven-Paars. Die spec.md ist mit der von Fall 06 Byte fuer Byte identisch, die specforge.json unterscheidet sich nur in der Perspektive. Fuer regulated_entity fuehrt die F-Stufen-Tabelle von @dora F4, die Einstufung des Autors passt, es bleibt beim nfr_gap.",
   "exit_code": 1,
   "ergebnis": "FAIL",
   "befunde": [

--- a/evals/golden/03-dora-regulated-ohne-irm01/spec.md
+++ b/evals/golden/03-dora-regulated-ohne-irm01/spec.md
@@ -1,0 +1,37 @@
+# Feature-Spezifikation: Auslagerung der Kontoführung an einen Cloud-Betreiber
+
+**ID:** SF-OUTSOURCING
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** kritis
+
+## 5. User Stories & Requirements
+
+### [SF-COM-001] Auslagerungsvertrag im Informationsregister führen
+
+**Typ**: Technical Story
+**Priorität**: MoSCoW: Must
+
+#### Story
+Als Auslagerungsbeauftragter möchte ich jeden IKT-Dienstleistungsvertrag im Informationsregister
+führen, damit die Aufsicht ihn ohne Nachfrage einsehen kann.
+
+#### EARS-Requirement
+**Pattern:** Ubiquitous
+Das Vertragsregister führt zu jedem IKT-Dienstleistungsvertrag Anbieter, Leistung, Kritikalität
+und Kündigungsfrist.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Neuer Vertrag wird aufgenommen
+  Given ein unterzeichneter IKT-Dienstleistungsvertrag
+  When der Auslagerungsbeauftragte ihn erfasst
+  Then enthält das Register Anbieter, Leistung, Kritikalität und Kündigungsfrist
+
+Scenario: Vertrag ohne Kritikalitätseinstufung
+  Given ein erfasster Vertrag ohne Kritikalitätseinstufung
+  When der Auslagerungsbeauftragte das Register abschließen will
+  Then verweigert das Register den Abschluss und benennt das fehlende Feld
+
+#### DORA-NFRs
+[NFR-Lücke F4: IRM-01 — IKT-Risikomanagement-Framework nicht spezifiziert — Gate: FAIL]

--- a/evals/golden/03-dora-regulated-ohne-irm01/specforge.json
+++ b/evals/golden/03-dora-regulated-ohne-irm01/specforge.json
@@ -1,0 +1,10 @@
+{
+  "profile": "kritis",
+  "perspective": "regulated_entity",
+  "severity_model": {
+    "F4": "FAIL", "F3": "CONDITIONAL", "F2": "WARNING",
+    "F1": "INFO", "F0": "PASS", "F5": "SKIP"
+  },
+  "extensions": ["@dora"],
+  "audit": true
+}

--- a/evals/golden/04-dora-advisory-ohne-irm01/expected.json
+++ b/evals/golden/04-dora-advisory-ohne-irm01/expected.json
@@ -1,0 +1,13 @@
+{
+  "beschreibung": "Beratungsprojekt ohne IKT-Risikomanagement-Framework. Perspektive advisory.",
+  "belegt": "Der Fall, an dem das alte Vokabular scheiterte: seine mittlere Stufe ergibt F3 und damit eine Risiko-Akzeptanz durch das Leitungsorgan, die F-Stufen-Tabelle von @dora sieht F2 vor. Das Gate ist passierbar, der Pflicht-Task bleibt.",
+  "exit_code": 0,
+  "ergebnis": "WARNING",
+  "befunde": [
+    {
+      "check": "nfr_gap",
+      "severity": "F2",
+      "subject": "IRM-01"
+    }
+  ]
+}

--- a/evals/golden/04-dora-advisory-ohne-irm01/expected.json
+++ b/evals/golden/04-dora-advisory-ohne-irm01/expected.json
@@ -1,6 +1,6 @@
 {
-  "beschreibung": "Beratungsprojekt ohne IKT-Risikomanagement-Framework. Perspektive advisory.",
-  "belegt": "Der Fall, an dem das alte Vokabular scheiterte: seine mittlere Stufe ergibt F3 und damit eine Risiko-Akzeptanz durch das Leitungsorgan, die F-Stufen-Tabelle von @dora sieht F2 vor. Das Gate ist passierbar, der Pflicht-Task bleibt.",
+  "beschreibung": "Beratungsprojekt ohne IKT-Risikomanagement-Framework, als F2 eingestuft. Perspektive advisory.",
+  "belegt": "Die zur Perspektive passende Einstufung passiert das Gate: F2 ergibt WARNING und einen Pflicht-Task vor Go-Live, keine Risiko-Akzeptanz durch das Leitungsorgan. Genau das war mit dem frueheren, dreistufigen Vokabular nicht darstellbar, dessen mittlere Stufe sich zu F3 uebersetzt.",
   "exit_code": 0,
   "ergebnis": "WARNING",
   "befunde": [

--- a/evals/golden/04-dora-advisory-ohne-irm01/spec.md
+++ b/evals/golden/04-dora-advisory-ohne-irm01/spec.md
@@ -1,0 +1,37 @@
+# Feature-Spezifikation: Beratungsprojekt Auslagerungsregister
+
+**ID:** SF-OUTSOURCING
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** kritis
+
+## 5. User Stories & Requirements
+
+### [SF-COM-001] Auslagerungsvertrag im Informationsregister führen
+
+**Typ**: Technical Story
+**Priorität**: MoSCoW: Must
+
+#### Story
+Als Auslagerungsbeauftragter möchte ich jeden IKT-Dienstleistungsvertrag im Informationsregister
+führen, damit die Aufsicht ihn ohne Nachfrage einsehen kann.
+
+#### EARS-Requirement
+**Pattern:** Ubiquitous
+Das Vertragsregister führt zu jedem IKT-Dienstleistungsvertrag Anbieter, Leistung, Kritikalität
+und Kündigungsfrist.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Neuer Vertrag wird aufgenommen
+  Given ein unterzeichneter IKT-Dienstleistungsvertrag
+  When der Auslagerungsbeauftragte ihn erfasst
+  Then enthält das Register Anbieter, Leistung, Kritikalität und Kündigungsfrist
+
+Scenario: Vertrag ohne Kritikalitätseinstufung
+  Given ein erfasster Vertrag ohne Kritikalitätseinstufung
+  When der Auslagerungsbeauftragte das Register abschließen will
+  Then verweigert das Register den Abschluss und benennt das fehlende Feld
+
+#### DORA-NFRs
+[NFR-Lücke F2: IRM-01 — IKT-Risikomanagement-Framework nicht spezifiziert — Gate: WARNING]

--- a/evals/golden/04-dora-advisory-ohne-irm01/specforge.json
+++ b/evals/golden/04-dora-advisory-ohne-irm01/specforge.json
@@ -1,0 +1,10 @@
+{
+  "profile": "standard",
+  "perspective": "advisory",
+  "severity_model": {
+    "F4": "FAIL", "F3": "CONDITIONAL", "F2": "WARNING",
+    "F1": "INFO", "F0": "PASS", "F5": "SKIP"
+  },
+  "extensions": ["@dora"],
+  "audit": true
+}

--- a/evals/golden/05-orphan-task/expected.json
+++ b/evals/golden/05-orphan-task/expected.json
@@ -1,0 +1,13 @@
+{
+  "beschreibung": "tasks.md mit einem Task ohne Story-Referenz.",
+  "belegt": "AP-07 ist F3, nicht F4: das Gate ist mit dokumentierter Risiko-Akzeptanz passierbar. Exit 2 unterscheidet diesen Fall von einem blockierenden Befund.",
+  "exit_code": 2,
+  "ergebnis": "CONDITIONAL",
+  "befunde": [
+    {
+      "check": "orphan_task",
+      "severity": "F3",
+      "subject": "T-002"
+    }
+  ]
+}

--- a/evals/golden/05-orphan-task/spec.md
+++ b/evals/golden/05-orphan-task/spec.md
@@ -1,0 +1,35 @@
+# Feature-Spezifikation: Rollenverwaltung im Meldeportal
+
+**ID:** SF-ROLLEN
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** standard
+
+## 5. User Stories & Requirements
+
+### [SF-FUNC-001] Rolle einem Konto zuweisen
+
+**Typ**: User Story
+**Priorität**: MoSCoW: Must
+
+#### Story
+Als Administrator möchte ich einem Konto eine Rolle zuweisen, damit die Berechtigung
+nachvollziehbar an der Rolle hängt und nicht am Konto.
+
+#### EARS-Requirement
+**Pattern:** Event-Driven
+Wenn ein Administrator eine Rolle zuweist, dann protokolliert die Rollenverwaltung Zeitpunkt,
+Konto, Rolle und den zuweisenden Administrator.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Rolle wird zugewiesen
+  Given ein bestehendes Konto ohne Rolle
+  When der Administrator die Rolle "Betriebsführer" zuweist
+  Then trägt das Konto die Rolle
+  And der Vorgang steht mit Zeitpunkt und Administrator im Protokoll
+
+Scenario: Zuweisung einer nicht vergebenen Rollenbezeichnung
+  Given ein bestehendes Konto ohne Rolle
+  When der Administrator eine nicht vergebene Rollenbezeichnung übermittelt
+  Then weist die Rollenverwaltung die Zuweisung zurück und nennt die gültigen Rollen

--- a/evals/golden/05-orphan-task/tasks.md
+++ b/evals/golden/05-orphan-task/tasks.md
@@ -1,0 +1,4 @@
+# Tasks: Rollenverwaltung im Meldeportal
+
+- [ ] T-001 Rollenzuweisung im Backend umsetzen (SF-FUNC-001) — Spec-First Steps 1,2,3
+- [ ] T-002 Protokollansicht im Frontend bauen — Spec-First Steps 4,6

--- a/evals/golden/05-orphan-task/tasks.md
+++ b/evals/golden/05-orphan-task/tasks.md
@@ -1,4 +1,4 @@
 # Tasks: Rollenverwaltung im Meldeportal
 
-- [ ] T-001 Rollenzuweisung im Backend umsetzen (SF-FUNC-001) — Spec-First Steps 1,2,3
-- [ ] T-002 Protokollansicht im Frontend bauen — Spec-First Steps 4,6
+- [ ] T-001 Rollenzuweisung im Backend umsetzen (SF-FUNC-001, Spec-First Steps 1,2,3)
+- [ ] T-002 Protokollansicht im Frontend bauen (Spec-First Steps 4,6)

--- a/evals/golden/06-dora-falsche-f-stufe/expected.json
+++ b/evals/golden/06-dora-falsche-f-stufe/expected.json
@@ -1,6 +1,6 @@
 {
-  "beschreibung": "Beratungsprojekt, das dieselbe Luecke wie Fall 04 als F4 einstuft.",
-  "belegt": "Eine zu hart eingestufte Luecke ist selbst ein Befund. Genau so entsteht ein Gate, das strenger blockiert als das Regelwerk verlangt.",
+  "beschreibung": "Dieselbe Spec wie Fall 03, dieselbe F4-Einstufung, Perspektive advisory.",
+  "belegt": "Die andere Haelfte des Perspektiven-Paars und der Beleg fuer die F-Stufen-Tabelle: identische spec.md, nur die Perspektive gewechselt, und der Befund nfr_severity kommt hinzu. Fuer advisory sieht @dora F2 vor, F4 blockiert haerter als das Regelwerk verlangt. Der Linter prueft dabei die Einstufung des Autors gegen das Manifest; die Stufe der Luecke selbst stammt weiterhin aus dem Marker.",
   "exit_code": 1,
   "ergebnis": "FAIL",
   "befunde": [

--- a/evals/golden/06-dora-falsche-f-stufe/expected.json
+++ b/evals/golden/06-dora-falsche-f-stufe/expected.json
@@ -1,0 +1,18 @@
+{
+  "beschreibung": "Beratungsprojekt, das dieselbe Luecke wie Fall 04 als F4 einstuft.",
+  "belegt": "Eine zu hart eingestufte Luecke ist selbst ein Befund. Genau so entsteht ein Gate, das strenger blockiert als das Regelwerk verlangt.",
+  "exit_code": 1,
+  "ergebnis": "FAIL",
+  "befunde": [
+    {
+      "check": "nfr_gap",
+      "severity": "F4",
+      "subject": "IRM-01"
+    },
+    {
+      "check": "nfr_severity",
+      "severity": "F3",
+      "subject": "IRM-01"
+    }
+  ]
+}

--- a/evals/golden/06-dora-falsche-f-stufe/spec.md
+++ b/evals/golden/06-dora-falsche-f-stufe/spec.md
@@ -1,4 +1,4 @@
-# Feature-Spezifikation: Beratungsprojekt Auslagerungsregister
+# Feature-Spezifikation: Auslagerungsregister für IKT-Dienstleistungsverträge
 
 **ID:** SF-OUTSOURCING
 **Version:** 2026.09.04.1

--- a/evals/golden/06-dora-falsche-f-stufe/spec.md
+++ b/evals/golden/06-dora-falsche-f-stufe/spec.md
@@ -1,0 +1,37 @@
+# Feature-Spezifikation: Beratungsprojekt Auslagerungsregister
+
+**ID:** SF-OUTSOURCING
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** kritis
+
+## 5. User Stories & Requirements
+
+### [SF-COM-001] Auslagerungsvertrag im Informationsregister führen
+
+**Typ**: Technical Story
+**Priorität**: MoSCoW: Must
+
+#### Story
+Als Auslagerungsbeauftragter möchte ich jeden IKT-Dienstleistungsvertrag im Informationsregister
+führen, damit die Aufsicht ihn ohne Nachfrage einsehen kann.
+
+#### EARS-Requirement
+**Pattern:** Ubiquitous
+Das Vertragsregister führt zu jedem IKT-Dienstleistungsvertrag Anbieter, Leistung, Kritikalität
+und Kündigungsfrist.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Neuer Vertrag wird aufgenommen
+  Given ein unterzeichneter IKT-Dienstleistungsvertrag
+  When der Auslagerungsbeauftragte ihn erfasst
+  Then enthält das Register Anbieter, Leistung, Kritikalität und Kündigungsfrist
+
+Scenario: Vertrag ohne Kritikalitätseinstufung
+  Given ein erfasster Vertrag ohne Kritikalitätseinstufung
+  When der Auslagerungsbeauftragte das Register abschließen will
+  Then verweigert das Register den Abschluss und benennt das fehlende Feld
+
+#### DORA-NFRs
+[NFR-Lücke F4: IRM-01 — IKT-Risikomanagement-Framework nicht spezifiziert — Gate: FAIL]

--- a/evals/golden/06-dora-falsche-f-stufe/specforge.json
+++ b/evals/golden/06-dora-falsche-f-stufe/specforge.json
@@ -1,0 +1,10 @@
+{
+  "profile": "standard",
+  "perspective": "advisory",
+  "severity_model": {
+    "F4": "FAIL", "F3": "CONDITIONAL", "F2": "WARNING",
+    "F1": "INFO", "F0": "PASS", "F5": "SKIP"
+  },
+  "extensions": ["@dora"],
+  "audit": true
+}

--- a/evals/golden/07-spec-ohne-story/expected.json
+++ b/evals/golden/07-spec-ohne-story/expected.json
@@ -1,0 +1,13 @@
+{
+  "beschreibung": "Spec mit Kopf und Gliederung, aber ohne einzige Story.",
+  "belegt": "Ein Lauf ohne Pruefgegenstand ist kein bestandener Lauf. Vor diesem Fall meldete der Checker '0/0 Stories' und Exit 0, womit ein abgeschnittenes Artefakt und ein falscher Pfad das Gate passierten.",
+  "exit_code": 1,
+  "ergebnis": "FAIL",
+  "befunde": [
+    {
+      "check": "no_stories",
+      "severity": "F4",
+      "subject": "spec.md"
+    }
+  ]
+}

--- a/evals/golden/07-spec-ohne-story/spec.md
+++ b/evals/golden/07-spec-ohne-story/spec.md
@@ -1,0 +1,17 @@
+# Feature-Spezifikation: Zahlungsavis-Verarbeitung
+
+**ID:** SF-AVIS
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** standard
+
+## 1. Kontext
+
+Die Verarbeitung eingehender Zahlungsavise soll von der Batch-Strecke auf
+einen laufenden Dienst umgestellt werden.
+
+## 5. User Stories & Requirements
+
+Der Abschnitt ist angelegt, die Stories fehlen noch. Genau so sieht ein
+abgeschnittenes Artefakt aus: eine Datei mit Kopf, Gliederung und ohne
+Inhalt.

--- a/evals/golden/08-dora-luecke-undokumentiert/expected.json
+++ b/evals/golden/08-dora-luecke-undokumentiert/expected.json
@@ -1,0 +1,7 @@
+{
+  "beschreibung": "Dieselbe Spec wie Fall 03, aber ohne den Marker: die IRM-01-Luecke ist nirgends dokumentiert.",
+  "belegt": "Haelt eine Grenze fest, kein gewuenschtes Verhalten. Der Linter liest NFR-Luecken aus den Markern der Spec; eine Anforderung, die niemand als fehlend markiert hat, sieht er nicht, und der Lauf endet mit PASS und Exit 0. Wer die Vollstaendigkeitspruefung braucht, braucht den NFR-Scan der Session gegen die Checkliste. Faellt dieser Fall eines Tages auf Exit 1, ist das kein Fehler, sondern eine neue Faehigkeit, und der Fall wird umgeschrieben.",
+  "exit_code": 0,
+  "ergebnis": "PASS",
+  "befunde": []
+}

--- a/evals/golden/08-dora-luecke-undokumentiert/spec.md
+++ b/evals/golden/08-dora-luecke-undokumentiert/spec.md
@@ -34,4 +34,3 @@ Scenario: Vertrag ohne Kritikalitätseinstufung
   Then verweigert das Register den Abschluss und benennt das fehlende Feld
 
 #### DORA-NFRs
-[NFR-Lücke F4: IRM-01 — IKT-Risikomanagement-Framework nicht spezifiziert — Gate: FAIL]

--- a/evals/golden/08-dora-luecke-undokumentiert/specforge.json
+++ b/evals/golden/08-dora-luecke-undokumentiert/specforge.json
@@ -1,6 +1,6 @@
 {
   "profile": "kritis",
-  "perspective": "advisory",
+  "perspective": "regulated_entity",
   "severity_model": {
     "F4": "FAIL", "F3": "CONDITIONAL", "F2": "WARNING",
     "F1": "INFO", "F0": "PASS", "F5": "SKIP"

--- a/evals/run_static.py
+++ b/evals/run_static.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Faehrt specforge check ueber die Golden Specs und vergleicht mit expected.json.
+
+Ebene 1 der Eval-Suite: deterministisch, ohne Netz, ohne Modell, ohne
+Schluessel. Was hier gruen ist, bleibt gruen — eine Abweichung ist eine
+Regression und keine Schwankung.
+
+Ebene 2, also das Nachfahren derselben Faelle durch die Claude-API, ist
+bewusst nicht Teil dieses Skripts. Ein Lauf gegen ein Sprachmodell ist nicht
+reproduzierbar und gehoert nicht in eine Pipeline, die bei jedem Push laeuft.
+
+Aufruf:
+
+    python3 evals/run_static.py            alle Faelle
+    python3 evals/run_static.py 04         nur passende Faelle
+    python3 evals/run_static.py --ausgabe  zusaetzlich die Gate-Ausgabe zeigen
+
+Exit 0 wenn alle Faelle bestehen, sonst 1. Nur Standardbibliothek.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+GOLDEN = "golden"
+EXPECTED = "expected.json"
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def cases(root, filters):
+    base = os.path.join(root, "evals", GOLDEN)
+    found = []
+    for name in sorted(os.listdir(base)):
+        directory = os.path.join(base, name)
+        if not os.path.isfile(os.path.join(directory, EXPECTED)):
+            continue
+        if filters and not any(needle in name for needle in filters):
+            continue
+        found.append((name, directory))
+    return found
+
+
+def load_expected(directory):
+    with open(os.path.join(directory, EXPECTED), encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def run_check(root, directory, extra=()):
+    command = [sys.executable, os.path.join(root, "cli", "specforge"),
+               "check", directory, "--json"] + list(extra)
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def gate_output(root, directory):
+    command = [sys.executable, os.path.join(root, "cli", "specforge"),
+               "check", directory]
+    return subprocess.run(command, capture_output=True, text=True).stdout
+
+
+def as_tuples(items):
+    return sorted((item["check"], item["severity"], item["subject"])
+                  for item in items)
+
+
+def compare(name, expected, process):
+    """Gibt eine Liste von Abweichungen zurueck, leer heisst bestanden."""
+    problems = []
+    if process.returncode != expected["exit_code"]:
+        problems.append("Exit-Code %d statt %d"
+                        % (process.returncode, expected["exit_code"]))
+    try:
+        actual = json.loads(process.stdout)
+    except ValueError:
+        problems.append("Ausgabe ist kein JSON: %s"
+                        % (process.stderr.strip() or process.stdout[:120]))
+        return problems
+
+    found = as_tuples(actual["findings"])
+    wanted = as_tuples(expected["befunde"])
+    if found != wanted:
+        for item in wanted:
+            if item not in found:
+                problems.append("erwarteter Befund fehlt: %s" % (item,))
+        for item in found:
+            if item not in wanted:
+                problems.append("unerwarteter Befund: %s" % (item,))
+    return problems
+
+
+def main(argv):
+    show_output = "--ausgabe" in argv
+    filters = [arg for arg in argv if not arg.startswith("--")]
+
+    root = repo_root()
+    selected = cases(root, filters)
+    if not selected:
+        print("Keine Faelle gefunden.")
+        return 1
+
+    failed = []
+    print("Golden Specs, Ebene 1 (deterministisch)")
+    print("")
+    for name, directory in selected:
+        expected = load_expected(directory)
+        process = run_check(root, directory)
+        problems = compare(name, expected, process)
+        status = "bestanden" if not problems else "ABWEICHUNG"
+        print("  %-32s %-10s Exit %d, erwartet %d, %d Befund(e)"
+              % (name, status, process.returncode, expected["exit_code"],
+                 len(expected["befunde"])))
+        print("      %s" % expected["beschreibung"])
+        if show_output:
+            for line in gate_output(root, directory).split("\n"):
+                print("      | %s" % line)
+        for problem in problems:
+            print("      -> %s" % problem)
+        if problems:
+            failed.append(name)
+
+    print("")
+    print("%d von %d Faellen bestanden"
+          % (len(selected) - len(failed), len(selected)))
+    if failed:
+        print("Abweichungen: %s" % ", ".join(failed))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/evals/run_static.py
+++ b/evals/run_static.py
@@ -3,7 +3,7 @@
 """Faehrt specforge check ueber die Golden Specs und vergleicht mit expected.json.
 
 Ebene 1 der Eval-Suite: deterministisch, ohne Netz, ohne Modell, ohne
-Schluessel. Was hier gruen ist, bleibt gruen — eine Abweichung ist eine
+Schluessel. Was hier gruen ist, bleibt gruen; eine Abweichung ist eine
 Regression und keine Schwankung.
 
 Ebene 2, also das Nachfahren derselben Faelle durch die Claude-API, ist

--- a/examples/example-prompts.md
+++ b/examples/example-prompts.md
@@ -35,8 +35,8 @@ Das System ist KRITIS-relevant. Profil: KRITIS.
 ## Modus 2: Clarify
 
 ```
-Kläre die offenen Fragen in meiner Spec. Fokussiere auf Blocker, die die
-Planung verhindern würden.
+Kläre die offenen Fragen in meiner Spec. Fokussiere auf die Punkte, die
+die Planung verhindern würden.
 ```
 
 ---

--- a/index.html
+++ b/index.html
@@ -632,7 +632,7 @@ Gherkin-Szenarien ─── Testfall-Ableitung ─── Testabdeckungsmatrix �
             <tr><td>Cynefin Framework</td><td>Dave Snowden (1999)</td><td>Phase 0 — Komplexitätseinschätzung</td></tr>
             <tr><td>Impact Mapping</td><td>Gojko Adzic (2012)</td><td>Phase 0 — Scope-Validierung</td></tr>
             <tr><td>Socratic Method</td><td>Platon/Sokrates</td><td>Clarify-Modus</td></tr>
-            <tr><td>Five Whys</td><td>Taiichi Ohno (Toyota)</td><td>BLOCKER-Analyse</td></tr>
+            <tr><td>Five Whys</td><td>Taiichi Ohno (Toyota)</td><td>F4-Analyse in Clarify</td></tr>
             <tr><td>MECE Principle</td><td>Barbara Minto (McKinsey)</td><td>Analyze-Modus</td></tr>
             <tr><td>Devil's Advocate + Steelmanning</td><td>Advocatus Diaboli (1587)</td><td>Stakeholder-Simulation</td></tr>
             <tr><td>Morphological Box + Pugh Matrix</td><td>Fritz Zwicky (1940er) / Stuart Pugh (1991)</td><td>Technologieentscheidungen</td></tr>

--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@
         <div class="feature">
           <span class="icon">4</span>
           <h3>Analyze</h3>
-          <p>MECE-Konsistenzprüfung über 5 Dimensionen mit Re-Analyze-Loop (max. 5 Iterationen) bis keine Blocker offen sind.</p>
+          <p>MECE-Konsistenzprüfung über 5 Dimensionen mit Re-Analyze-Loop (max. 5 Iterationen) bis kein F4-Befund offen ist.</p>
         </div>
         <div class="feature">
           <span class="icon">5</span>
@@ -427,7 +427,7 @@
         </div>
         <div class="feature" style="text-align:center;">
           <h3 style="margin-bottom:8px; font-size:1.1rem;">Plan Fidelity Check</h3>
-          <p style="color:var(--text-muted); font-size:0.95rem;">Der Review-Modus prüft den Code-Diff hart gegen die <code>plan.md</code>. Unerlaubter Drift wird als F3-Gate-Blocker markiert.</p>
+          <p style="color:var(--text-muted); font-size:0.95rem;">Der Review-Modus prüft den Code-Diff hart gegen die <code>plan.md</code>. Unerlaubter Drift wird als F3-Befund markiert und braucht eine dokumentierte Risiko-Akzeptanz.</p>
         </div>
         <div class="feature" style="text-align:center;">
           <h3 style="margin-bottom:8px; font-size:1.1rem;">Prompt Diet</h3>

--- a/references/01-specify.md
+++ b/references/01-specify.md
@@ -128,7 +128,7 @@ SpecForge prüft diese Checkliste und gibt ein Pass/Fail-Ergebnis aus:
 [ ] Constitution: vorhanden und referenziert
 [ ] specforge.json: vorhanden mit Profil
 [ ] STRIDE: laut Profil geprüft
-[ ] Keine offenen BLOCKER-Fragen
+[ ] Keine offenen F4-Fragen
 ── Ergebnis: PASS | FAIL (Befunde) ─────────
 ```
 
@@ -142,15 +142,15 @@ SpecForge prüft diese Checkliste und gibt ein Pass/Fail-Ergebnis aus:
 
 | Regel | Enforcement | Schweregrad |
 |-------|-----------|------------|
-| Vage Begriffe aus Blocklist | Jede Story gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | BLOCKER |
-| EARS-Pflicht | Jede Story hat explizit benanntes EARS-Pattern | MAJOR |
-| Gherkin-Minimum | ≥2 Szenarien pro Story (Happy Path + Fehlerfall) → AP-06 | MAJOR |
+| Vage Begriffe aus Blocklist | Jede Story gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | F4 |
+| EARS-Pflicht | Jede Story hat explizit benanntes EARS-Pattern | F4 |
+| Gherkin-Minimum | ≥2 Szenarien pro Story (Gate G1); nur Happy Path trotz ≥2 Szenarien → AP-06 (F3) | F4 |
 | Anti-Pattern-Prüfung | AP-01–AP-08 bei jeder Story-Erzeugung prüfen | Schweregrad laut AP-Tabelle |
 | Offene-Punkte-Marker | Fehlende Details als `[Offen: ...]` markieren statt Story zu blockieren | F3 (nach Clarify) |
 | Fragen-Budget | Max. 3 Fragen pro Runde an den Nutzer | n.a. |
-| Artefakt-Erzeugung als Datei | spec.md, constitution.md, specforge.json als Dateien, nicht inline | MAJOR |
+| Artefakt-Erzeugung als Datei | spec.md, constitution.md, specforge.json als Dateien, nicht inline | F2 |
 | Schweregrad-Zuweisung | Deterministisch nach enforcement-engine.md | n.a. |
-| ID-Schema | SF-[Präfix]-[NNN] Format (z.B. SF-FUNC-001) | MINOR |
+| ID-Schema | SF-[Präfix]-[NNN] Format (z.B. SF-FUNC-001) | F1 |
 
 ## Erweiterbarkeit
 

--- a/references/02-clarify.md
+++ b/references/02-clarify.md
@@ -48,16 +48,16 @@ Für jede Lücke gezielte Fragen nach Hierarchie:
 - Max. 5 Fragen pro Runde (priorisiert nach Schweregrad)
 - Jede Frage referenziert die betroffene Story-ID oder Spec-Abschnitt
 - Fragen bieten konkrete Optionen — keine offenen "was meinen Sie"-Fragen
-- Schweregrad pro Frage: `[BLOCKER]` | `[MAJOR]` | `[MINOR]`
+- F-Stufe pro Frage: `[F4]` | `[F3]` | `[F2]` | `[F1]`
 
-### Bei BLOCKER: Five Whys anwenden
+### Bei F4: Five Whys anwenden
 
 Max. 5 Iterationen. Stopp bei handlungsfähiger Grundursache. Fokus auf Prozess-/Architekturlücken, nicht Schuldzuweisung.
 
 ### Frageformat
 
 ```markdown
-**[BLOCKER] SF-SEC-001 — Authentifizierung**
+**[F4] SF-SEC-001 — Authentifizierung**
 Sokratische Ebene: Annahme hinterfragen
 Die Spec definiert "sichere Authentifizierung" ohne konkretes Verfahren.
 Implizite Annahme: "Sicher" ist selbsterklärend.
@@ -96,9 +96,11 @@ Nach Klärung betroffene Requirements aktualisieren:
 ## Abschlusskriterium
 
 Clarify ist abgeschlossen wenn:
-- Keine `[BLOCKER]`-Fragen mehr offen
-- `[MAJOR]`-Fragen dürfen mit dokumentierter Begründung in Plan-Phase mitgenommen werden
-- `[MINOR]`-Fragen als bekannte Lücken dokumentiert
+- Keine `[F4]`-Fragen mehr offen
+- `[F3]`-Fragen dürfen mit dokumentierter Risiko-Akzeptanz in die Plan-Phase mitgenommen werden
+- `[F2]`-Fragen erzeugen je einen Pflicht-Task vor Go-Live
+- `[F1]`-Fragen als bekannte Lücken dokumentiert
+- `[F5]`-Fragen mit Begründung im Audit Trail übersprungen
 
 ---
 
@@ -106,9 +108,9 @@ Clarify ist abgeschlossen wenn:
 
 ```
 ── Gate G2: Clarify → Plan ────────────────
-[ ] Keine offenen [BLOCKER]-Fragen
+[ ] Keine offenen [F4]-Fragen
 [ ] Clarifications-Abschnitt in spec.md vorhanden
-[ ] [MAJOR]-Fragen mit Begründung dokumentiert oder gelöst
+[ ] [F3]-Fragen mit Risiko-Akzeptanz dokumentiert oder gelöst
 [ ] Vage Begriffe durch quantifizierte Werte ersetzt
 [ ] [Annahme: ...]-Marker bestätigt oder verworfen
 ── Ergebnis: PASS | FAIL (Befunde) ─────────
@@ -120,12 +122,12 @@ Clarify ist abgeschlossen wenn:
 
 | Regel | Enforcement | Schweregrad |
 |-------|-----------|------------|
-| Vage Begriffe aus Blocklist | Jede Clarification gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | BLOCKER |
+| Vage Begriffe aus Blocklist | Jede Clarification gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | F4 |
 | Fragen-Budget | Max. 5 Fragen pro Runde (Clarify-spezifisch, sonst 3) | n.a. |
-| BLOCKER-Fragen vor Plan lösen | Offene BLOCKER-Fragen blockieren Gate G2 | BLOCKER |
+| F4-Fragen vor Plan lösen | Offene F4-Fragen blockieren Gate G2 | F4 |
 | Anti-Pattern-Prüfung | AP-01–AP-08 bei jeder Reformulierung | Schweregrad laut AP-Tabelle |
-| Artefakt-Aktualisierung als Datei | Clarifications in spec.md als Datei, nicht inline | MAJOR |
-| Schweregrad-Zuweisung | Deterministisch: Fragen mit Architektur-Impact = BLOCKER, Fragen zu Details = MAJOR, Verständnisfragen = MINOR | n.a. |
+| Artefakt-Aktualisierung als Datei | Clarifications in spec.md als Datei, nicht inline | F2 |
+| F-Stufen-Zuweisung | Deterministisch: Architektur- oder Schnittstellen-Impact = F4, Detailentscheidung mit Risikowirkung = F3, Detailfrage ohne Risikowirkung = F2, Verständnisfrage = F1, für dieses Projekt nicht anwendbar = F5 | n.a. |
 
 ## Erweiterbarkeit
 

--- a/references/03-plan.md
+++ b/references/03-plan.md
@@ -156,7 +156,7 @@ Nicht jeder Task durchläuft alle 8 Schritte — markieren, welche relevant sind
 - Jeder Task hat Gherkin ACs (≥2 Szenarien, AP-06)
 - Jeder Task hat Spec-Referenz (GP-02, AP-05 Scope Creep)
 - NFR-Tasks explizit ausweisen mit Kategorie (AVA/SEC/AUD/PER/DAT/OPS)
-- **GP-04: Tasks mit 5+ Dateien → ExecPlan-Pflicht (EP-*.md)** — Verstoß = MAJOR
+- **GP-04: Tasks mit 5+ Dateien → ExecPlan-Pflicht (EP-*.md)** — Verstoß = F2
   - ExecPlan enthält: Änderungsreihenfolge, Abhängigkeiten, Rollback-Strategie, Checkpoint
   - ExecPlan-Pfad: `plans/active/EP-*.md`
 - Definition-of-Ready-Prüfung pro Task:
@@ -192,12 +192,12 @@ Empfehlung: IMMER Analyze nach Tasks ausführen.
 
 | Regel | Enforcement | Schweregrad |
 |-------|-----------|------------|
-| Vage Begriffe in plan.md/tasks.md | Jedes Artefakt gegen Blocklist: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | BLOCKER |
+| Vage Begriffe in plan.md/tasks.md | Jedes Artefakt gegen Blocklist: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | F4 |
 | Fragen-Budget | Max. 3 Fragen pro Runde an den Nutzer | n.a. |
-| ExecPlan-Pflicht (GP-04) | Automatisch bei Tasks mit 5+ Dateien | MAJOR |
-| ADR-Pflicht (GP-03) | Automatisch bei modulübergreifenden Entscheidungen | MAJOR (KRITIS: BLOCKER) |
+| ExecPlan-Pflicht (GP-04) | Automatisch bei Tasks mit 5+ Dateien | F2 |
+| ADR-Pflicht (GP-03) | Automatisch bei modulübergreifenden Entscheidungen | F3 (KRITIS: F4) |
 | Anti-Pattern-Prüfung | AP-01–AP-08 bei jedem Task | Schweregrad laut AP-Tabelle |
-| Artefakte als Dateien | plan.md, tasks.md, research.md als Dateien, nicht inline | MAJOR |
+| Artefakte als Dateien | plan.md, tasks.md, research.md als Dateien, nicht inline | F2 |
 | Schweregrad-Zuweisung | Deterministisch nach enforcement-engine.md | n.a. |
 
 ## Erweiterbarkeit
@@ -217,7 +217,7 @@ Empfehlung: IMMER Analyze nach Tasks ausführen.
 | spec.md fehlt | → Fehlermeldung: "spec.md nicht gefunden — Clarify (Modus 2) oder Specify (Modus 1) zuerst ausführen" |
 | specforge.json fehlt | → Standard-Profil anwenden, Hinweis ausgeben |
 | Keine ADR-Entscheidungen identifizierbar | → Hinweis: "Keine modulübergreifenden Entscheidungen erkannt — ADR optional" |
-| Task mit 5+ Dateien ohne ExecPlan | → MAJOR-Finding, ExecPlan-Erstellung anbieten |
+| Task mit 5+ Dateien ohne ExecPlan | → F2-Befund, ExecPlan-Erstellung anbieten |
 | Research-Quellen nicht erreichbar | → Befund dokumentieren, Konfidenz auf "Niedrig" setzen |
 | Profil-Wechsel mid-session | → Plan-Scope anpassen (Research Pflicht/Optional, ADR-Tiefe) |
 | Brownfield ohne ARCHITECTURE.md | → ARCHITECTURE.md aus Code ableiten (Discover-Aspekte) |

--- a/references/04-analyze.md
+++ b/references/04-analyze.md
@@ -5,7 +5,7 @@
 
 ## Profil-Steuerung
 
-- **KRITIS:** Analyze Pflicht; Loop bis Blocker-frei UND GP-Score ≥ 9/10; Alle 5+1 Dimensionen; Custom Checks falls konfiguriert
+- **KRITIS:** Analyze Pflicht; Loop bis kein F4-Befund mehr offen ist UND GP-Score ≥ 9/10; Alle 5+1 Dimensionen; Custom Checks falls konfiguriert
 - **Standard:** Analyze empfohlen; Loop bis GP-Score ≥ 8/10; Dimensionen 1–5; Custom optional
 - **Startup:** Analyze optional; GP-Score ≥ 6/10; Dimensionen 1–3 Pflicht, 4–5 empfohlen
 
@@ -57,12 +57,12 @@ Alle Checker arbeiten unabhängig. Jeder Checker erzeugt einen eigenständigen B
 **Scope:** Dimensionen [1–6] / [1–5] / [1–3]
 
 ### Checker-Ergebnisse
-| Checker | Status | Befunde (B/M/m) | Blocker |
-|---------|--------|-----------------|---------|
-| Consistency | ✅/⚠️/❌ | X/Y/Z | [Anzahl] |
-| GP Auditor | [Score]/10 | X/Y/Z | [Anzahl] |
-| Security | ✅/⚠️/❌ | X/Y/Z | [Anzahl] |
-| Custom | ✅/n.a. | X/Y/Z | — |
+| Checker | Status | Befunde (F4/F3/F2/F1) |
+|---------|--------|----------------------|
+| Consistency | ✅/⚠️/❌ | W/X/Y/Z |
+| GP Auditor | [Score]/10 | W/X/Y/Z |
+| Security | ✅/⚠️/❌ | W/X/Y/Z |
+| Custom | ✅/n.a. | W/X/Y/Z |
 
 ### Detailbefunde
 | # | Checker | Schweregrad | Befund | Betroffene Artefakte | Empfohlene Aktion |

--- a/references/04-analyze.md
+++ b/references/04-analyze.md
@@ -25,11 +25,11 @@ Die Analyze-Phase nutzt spezialisierte Checker-Perspektiven, die unabhängig und
 
 | # | Dimension | Prüft | Schweregrad bei Lücke |
 |---|-----------|-------|-----------------------|
-| 1 | Spec ↔ Plan | Jedes Requirement hat Entsprechung im Plan; ADRs vorhanden (GP-03) | MAJOR |
-| 2 | Plan ↔ Tasks | Jede Plan-Komponente hat Task; Reihenfolge respektiert Abhängigkeiten | MAJOR |
-| 3 | Spec ↔ Tasks | Jede Story durch Task abgedeckt; keine verwaisten Tasks/Requirements (AP-05, AP-07) | BLOCKER |
+| 1 | Spec ↔ Plan | Jedes Requirement hat Entsprechung im Plan; ADRs vorhanden (GP-03) | F3 (KRITIS: F4) |
+| 2 | Plan ↔ Tasks | Jede Plan-Komponente hat Task; Reihenfolge respektiert Abhängigkeiten | F3 |
+| 3 | Spec ↔ Tasks | Jede Story durch Task abgedeckt; keine verwaisten Tasks/Requirements (AP-05, AP-07) | F4 |
 | 4 | Governance | GP-Compliance laut Profil; ExecPlans (GP-04); Folder Convention (GP-07); stale Marker (GP-06) | Schweregrad laut GP |
-| 5 | Security & Compliance | STRIDE; NFRs; NIS2; DSGVO — Scope laut Profil | MAJOR (KRITIS: BLOCKER) |
+| 5 | Security & Compliance | STRIDE; NFRs; NIS2; DSGVO — Scope laut Profil | F3 (KRITIS: F4) |
 | 6 | Custom | Projektspezifische Prüfregeln (nur wenn `custom_checklists` in specforge.json) | Konfigurierbar |
 | 7 | Story-Quality | Numerischer SQS pro Story (Titel, Description, Gherkin, SOPHIST, EARS) — Details in 07-review.md | F3 (SQS < 2.0), F2 (SQS 2.0–2.9), F1 (SQS 3.0–3.9) |
 
@@ -47,7 +47,7 @@ Alle Checker arbeiten unabhängig. Jeder Checker erzeugt einen eigenständigen B
 1. Checker-Reports zusammenführen
 2. Bei Widersprüchen zwischen Checkern: höherer Schweregrad gewinnt
 3. GP-Score berechnen: `Erfüllte GPs / Aktive GPs laut Profil`
-4. Sortierung: BLOCKER → MAJOR → MINOR
+4. Sortierung: F4 → F3 → F2 → F1
 
 ## Output: Konsolidierter Analyze-Report (deterministisch)
 
@@ -67,19 +67,19 @@ Alle Checker arbeiten unabhängig. Jeder Checker erzeugt einen eigenständigen B
 ### Detailbefunde
 | # | Checker | Schweregrad | Befund | Betroffene Artefakte | Empfohlene Aktion |
 |---|---------|------------|--------|---------------------|------------------|
-| A-001 | Consistency | BLOCKER | Orphan Task T-005 | tasks.md | Spec-Referenz ergänzen |
+| A-001 | Consistency | F4 | Orphan Task T-005 | tasks.md | Spec-Referenz ergänzen |
 
 ### Gesamtbewertung
 **Implementierungs-Readiness:** [Bereit / Überarbeitung nötig / Nicht bereit]
 **GP-Score:** [X/10] (Schwelle: [Y/10])
-**BLOCKER:** [Anzahl] | **MAJOR:** [Anzahl] | **MINOR:** [Anzahl]
+**F4:** [Anzahl] | **F3:** [Anzahl] | **F2:** [Anzahl] | **F1:** [Anzahl]
 ```
 
 ## Phase Gate G4: Analyze → Implement (automatisch prüfen)
 
 ```
 ── Gate G4: Analyze → Implement ────────────
-[ ] Keine BLOCKER-Befunde offen
+[ ] Keine F4-Befunde offen
 [ ] GP-Score ≥ Profil-Schwelle (KRITIS: 9, Standard: 8, Startup: 6)
 [ ] STRIDE vollständig (laut Profil)
 [ ] Custom-Checks bestanden (falls vorhanden)

--- a/references/06-stakeholder-sim.md
+++ b/references/06-stakeholder-sim.md
@@ -24,11 +24,11 @@
 
 ## Regeln (Enforcement)
 
-1. **Rollenanzahl:** Min. 3, max. 5 Rollen pro Simulation — Unterschreitung = BLOCKER
-2. **Pflicht-Rollen nach Profil:** Siehe Profil-Steuerung oben — fehlende Pflicht-Rolle = BLOCKER
+1. **Rollenanzahl:** Min. 3, max. 5 Rollen pro Simulation — Unterschreitung = F4
+2. **Pflicht-Rollen nach Profil:** Siehe Profil-Steuerung oben — fehlende Pflicht-Rolle = F4
 3. **Steelmanning-Pflicht:** Jede Rolle muss mindestens eine Annahme explizit in Frage stellen und die stärkste Version der Gegenposition formulieren (kein Strohmann)
 4. **Findings-Pflicht:** Jede Rolle muss mindestens ein Finding mit Schweregrad liefern
-5. **Schweregrad-Zuweisung:** Jedes Finding wird klassifiziert: BLOCKER / MAJOR / MINOR — Zuordnung ist deterministisch nach denselben Regeln wie enforcement-engine.md
+5. **F-Stufen-Zuweisung:** Jedes Finding wird nach F0 bis F5 klassifiziert — Zuordnung ist deterministisch nach denselben Regeln wie enforcement-engine.md
 6. **Anti-Pattern-Prüfung:** AP-01–AP-08 werden von jeder Rolle mitgeprüft; Findings bei Erkennung sind Pflicht
 7. **GP-Referenz:** Jedes Finding referenziert den betroffenen GP (z.B. "Verstoß gegen GP-03: ADR fehlt")
 
@@ -58,10 +58,10 @@ Jede Rolle durchläuft denselben 4-Schritt-Prozess:
 
 ### Phase 6c: Konsolidierung
 1. Alle Findings zusammenführen, Duplikate mit höherem Schweregrad gewinnt
-2. Sortierung: BLOCKER → MAJOR → MINOR
+2. Sortierung: F4 → F3 → F2 → F1
 3. Konsolidiertes Protokoll erzeugen als Datei `stakeholder-sim-protocol.md`
 
-**Gate-Integration:** Stakeholder-Sim-Findings fließen in Gate G4 (Analyze → Implement) ein. BLOCKER-Findings aus der Simulation blockieren den Gate-Übergang, bis sie gelöst sind.
+**Gate-Integration:** Stakeholder-Sim-Findings fließen in Gate G4 (Analyze → Implement) ein. F4-Findings aus der Simulation blockieren den Gate-Übergang, bis sie gelöst sind. F3-Findings machen das Gate CONDITIONAL.
 
 ### Phase 6d: Integration (optional)
 - Nutzer entscheidet: Findings direkt in spec.md einarbeiten oder als Backlog-Items dokumentieren
@@ -80,7 +80,7 @@ Jede Rolle durchläuft denselben 4-Schritt-Prozess:
 #### [Rolle 1: Name]
 | # | Finding | Schweregrad | Betroffener GP | Annahme hinterfragt | Empfehlung |
 |---|---------|------------|---------------|---------------------|------------|
-| F-01 | [Befund] | BLOCKER/MAJOR/MINOR | GP-XX | [Annahme] | [Aktion] |
+| F-01 | [Befund] | F4/F3/F2/F1 | GP-XX | [Annahme] | [Aktion] |
 
 #### [Rolle 2: Name]
 ...
@@ -88,10 +88,10 @@ Jede Rolle durchläuft denselben 4-Schritt-Prozess:
 ### Konsolidierte Findings
 | # | Finding | Schweregrad | Quelle (Rolle) | GP | Status |
 |---|---------|------------|----------------|-------|--------|
-| CF-01 | [Befund] | BLOCKER | Security Reviewer | GP-03 | Offen |
+| CF-01 | [Befund] | F4 | Security Reviewer | GP-03 | Offen |
 
 ### Zusammenfassung
-**BLOCKER:** [Anzahl] | **MAJOR:** [Anzahl] | **MINOR:** [Anzahl]
+**F4:** [Anzahl] | **F3:** [Anzahl] | **F2:** [Anzahl] | **F1:** [Anzahl]
 **Empfehlung:** [Freigabefähig / Überarbeitung empfohlen / Nicht freigabefähig]
 ```
 
@@ -101,14 +101,14 @@ Folgende Regeln werden **automatisch** bei jeder Simulation durchgesetzt:
 
 | Regel | Enforcement | Schweregrad bei Verstoß |
 |-------|-----------|------------------------|
-| Min. 3 Rollen aktiviert | Automatischer Check vor Simulation | BLOCKER |
-| Pflicht-Rollen laut Profil anwesend | Automatischer Check nach Rollenauswahl | BLOCKER |
-| Jede Rolle liefert ≥1 Finding mit Schweregrad | Automatischer Check nach Simulation | MAJOR |
-| Jede Rolle hinterfragt ≥1 Annahme | Automatischer Check nach Simulation | MAJOR |
-| Vage Begriffe aus Blocklist erkannt | Jedes Finding gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | BLOCKER |
+| Min. 3 Rollen aktiviert | Automatischer Check vor Simulation | F4 |
+| Pflicht-Rollen laut Profil anwesend | Automatischer Check nach Rollenauswahl | F4 |
+| Jede Rolle liefert ≥1 Finding mit F-Stufe | Automatischer Check nach Simulation | F2 |
+| Jede Rolle hinterfragt ≥1 Annahme | Automatischer Check nach Simulation | F2 |
+| Vage Begriffe aus Blocklist erkannt | Jedes Finding gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | F4 |
 | Fragen-Budget | Max. 3 Fragen pro Runde an den Nutzer; Stakeholder-Fragen intern unbegrenzt | n.a. (Budget-Überschreitung = Skip) |
 | Anti-Pattern-Prüfung | AP-01–AP-08 + custom APs aus `references/custom/anti-patterns-custom.md` | Schweregrad laut AP-Tabelle |
-| Spec-Artefakt als Datei | Output als stakeholder-sim-protocol.md, nicht inline | MAJOR |
+| Spec-Artefakt als Datei | Output als stakeholder-sim-protocol.md, nicht inline | F2 |
 
 ## Erweiterbarkeit
 
@@ -143,7 +143,7 @@ Folgende Regeln werden **automatisch** bei jeder Simulation durchgesetzt:
 | GP-05 | System Architect: Invariant-Traceability |
 | GP-06 | Harness Auditor: Stale Marker |
 | GP-07 | Harness Auditor: Folder Convention |
-| GP-08 | Alle: GP-Verstöße als BLOCKER |
+| GP-08 | Alle: GP-Verstöße als F4 |
 | GP-09 | Contract Guardian: Abhängigkeitsrichtung |
 | GP-10 | Harness Auditor: Tech-Debt dokumentiert |
 

--- a/references/07-review.md
+++ b/references/07-review.md
@@ -11,7 +11,7 @@
 
 - **KRITIS:** Alle 3 Ebenen Pflicht; STRIDE vollständig (alle 6 Kategorien); GP-Score ≥ 9/10; Keine offenen F4- oder F3-Befunde erlaubt
 - **Standard:** Ebene 1 + 2 Pflicht; Ebene 3 für SEC-Stories; GP-Score ≥ 8/10; F4 muss gelöst sein, F3 braucht dokumentierte Risiko-Akzeptanz
-- **Startup:** Ebene 1 Pflicht; Ebene 2 + 3 empfohlen; GP-Score ≥ 6/10; Soft-Empfehlungen statt Blocker
+- **Startup:** Ebene 1 Pflicht; Ebene 2 + 3 empfohlen; GP-Score ≥ 6/10; Soft-Empfehlungen statt F4
 
 ## Ablauf (deterministisch)
 

--- a/references/07-review.md
+++ b/references/07-review.md
@@ -9,8 +9,8 @@
 
 ## Profil-Steuerung
 
-- **KRITIS:** Alle 3 Ebenen Pflicht; STRIDE vollständig (alle 6 Kategorien); GP-Score ≥ 9/10; Keine offenen BLOCKER/MAJOR erlaubt
-- **Standard:** Ebene 1 + 2 Pflicht; Ebene 3 für SEC-Stories; GP-Score ≥ 8/10; BLOCKER müssen gelöst, MAJOR dokumentiert
+- **KRITIS:** Alle 3 Ebenen Pflicht; STRIDE vollständig (alle 6 Kategorien); GP-Score ≥ 9/10; Keine offenen F4- oder F3-Befunde erlaubt
+- **Standard:** Ebene 1 + 2 Pflicht; Ebene 3 für SEC-Stories; GP-Score ≥ 8/10; F4 muss gelöst sein, F3 braucht dokumentierte Risiko-Akzeptanz
 - **Startup:** Ebene 1 Pflicht; Ebene 2 + 3 empfohlen; GP-Score ≥ 6/10; Soft-Empfehlungen statt Blocker
 
 ## Ablauf (deterministisch)
@@ -33,14 +33,14 @@ Jede Ebene wird vollständig durchlaufen. Keine Ebene darf übersprungen werden,
 
 | # | Kriterium | Prüfung | Schweregrad bei Verstoß |
 |---|-----------|---------|------------------------|
-| RQ-01 | Eindeutigkeit | Keine vagen Begriffe aus Blocklist (enforcement-engine.md) | BLOCKER (AP-04) |
-| RQ-02 | Testbarkeit | Konkretes Pass/Fail-Kriterium vorhanden | MAJOR |
-| RQ-03 | EARS-Konformität | Explizit benanntes EARS-Pattern; korrekte Syntax | MAJOR |
-| RQ-04 | Gherkin-Qualität | ≥2 Szenarien pro Story (Happy Path + Fehlerfall) | MAJOR (AP-06) |
-| RQ-05 | Atomarität | Ein Requirement = eine testbare Aussage | MINOR |
+| RQ-01 | Eindeutigkeit | Keine vagen Begriffe aus Blocklist (enforcement-engine.md) | F4 (AP-04) |
+| RQ-02 | Testbarkeit | Konkretes Pass/Fail-Kriterium vorhanden | F3 |
+| RQ-03 | EARS-Konformität | Explizit benanntes EARS-Pattern; korrekte Syntax | F4 |
+| RQ-04 | Gherkin-Qualität | ≥2 Szenarien pro Story (Gate G1); nur Happy Path trotz ≥2 Szenarien → AP-06 (F3) | F4 |
+| RQ-05 | Atomarität | Ein Requirement = eine testbare Aussage | F1 |
 | RQ-06 | Anti-Pattern-Freiheit | AP-01 bis AP-08 geprüft | Schweregrad laut AP-Tabelle |
-| RQ-07 | Annahmen-Markierung | Alle Annahmen als `[Annahme: ...]` gekennzeichnet | MAJOR (AP-03) |
-| RQ-08 | ID-Schema | SF-[Präfix]-[NNN] Format eingehalten | MINOR |
+| RQ-07 | Annahmen-Markierung | Alle Annahmen als `[Annahme: ...]` gekennzeichnet | F3 (AP-03) |
+| RQ-08 | ID-Schema | SF-[Präfix]-[NNN] Format eingehalten | F1 |
 
 #### Story-Quality-Score (SQS) — numerische Qualitätsbewertung
 
@@ -132,11 +132,11 @@ Schwellwerte:
 ### Phase 7d: Konsolidierung
 
 1. Findings aller 3 Ebenen zusammenführen
-2. Sortierung: BLOCKER → MAJOR → MINOR
+2. Sortierung: F4 → F3 → F2 → F1
 3. Gesamtbewertung ableiten:
-   - **Freigabefähig:** Keine BLOCKER, GP-Score ≥ Schwelle
-   - **Überarbeitung empfohlen:** Keine BLOCKER, aber MAJOR-Findings > 3 oder GP-Score knapp
-   - **Nicht freigabefähig:** BLOCKER vorhanden oder GP-Score < Schwelle
+   - **Freigabefähig:** Keine F4-Befunde, GP-Score ≥ Schwelle
+   - **Überarbeitung empfohlen:** Keine F4-Befunde, aber mehr als 3 F3-Befunde oder GP-Score knapp
+   - **Nicht freigabefähig:** F4-Befund vorhanden oder GP-Score < Schwelle
 
 ## Output: Review-Protokoll (deterministisch)
 
@@ -149,20 +149,20 @@ Schwellwerte:
 ### Ebene 1 — Requirement-Qualität
 | # | Kriterium | Bewertung | Schweregrad | Befund | Vorschlag |
 |---|-----------|----------|------------|--------|-----------|
-| RQ-01 | Eindeutigkeit | ✅/❌ | — / BLOCKER | [Befund] | [Vorschlag] |
+| RQ-01 | Eindeutigkeit | ✅/❌ | — / F4 | [Befund] | [Vorschlag] |
 
 ### Ebene 2 — Governance-Compliance
 | # | Golden Principle | Status | Schweregrad | Befund | Aktion |
 |---|-----------------|--------|------------|--------|--------|
-| GC-01 | GP-01 | ✅/❌/n.a. | — / MAJOR | [Befund] | [Aktion] |
+| GC-01 | GP-01 | ✅/❌/n.a. | — / F3 | [Befund] | [Aktion] |
 
 ### Ebene 3 — Security & Compliance
 | Kategorie | Geprüft | Befund | Schweregrad | Mitigation |
 |-----------|---------|--------|------------|-----------|
-| Spoofing | ✅/❌ | [Befund] | MAJOR | [Maßnahme] |
+| Spoofing | ✅/❌ | [Befund] | F3 | [Maßnahme] |
 
 ### Zusammenfassung
-**BLOCKER:** [Anzahl] | **MAJOR:** [Anzahl] | **MINOR:** [Anzahl]
+**F4:** [Anzahl] | **F3:** [Anzahl] | **F2:** [Anzahl] | **F1:** [Anzahl]
 **GP-Score:** [X/10] (Schwelle: [Y/10])
 **Gesamtbewertung:** [Freigabefähig / Überarbeitung empfohlen / Nicht freigabefähig]
 ```
@@ -171,12 +171,12 @@ Schwellwerte:
 
 | Regel | Enforcement | Schweregrad |
 |-------|-----------|------------|
-| Vage Begriffe aus Blocklist | Automatisch in Ebene 1 (RQ-01): "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | BLOCKER |
+| Vage Begriffe aus Blocklist | Automatisch in Ebene 1 (RQ-01): "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | F4 |
 | Fragen-Budget | Max. 3 Fragen pro Runde an den Nutzer; Review-interne Prüfung unbegrenzt | n.a. |
 | Anti-Pattern-Prüfung | AP-01–AP-08 + custom APs aus `references/custom/anti-patterns-custom.md` | Schweregrad laut AP-Tabelle |
-| Artefakt-Erzeugung als Datei | review-protocol.md als separate Datei, nicht inline | MAJOR |
-| Gherkin-Minimum | ≥2 Szenarien pro Story (RQ-04) — Unterschreitung = MAJOR (AP-06) | MAJOR |
-| EARS-Pflicht | Jede Story hat explizit benanntes Pattern (RQ-03) | MAJOR |
+| Artefakt-Erzeugung als Datei | review-protocol.md als separate Datei, nicht inline | F2 |
+| Gherkin-Minimum | ≥2 Szenarien pro Story (RQ-04) — Unterschreitung blockiert Gate G1 | F4 |
+| EARS-Pflicht | Jede Story hat explizit benanntes Pattern (RQ-03) | F4 |
 | Schweregrad-Zuweisung | Deterministisch nach enforcement-engine.md Schweregrad-Tabelle | n.a. |
 
 ## Erweiterbarkeit
@@ -196,7 +196,7 @@ Schwellwerte:
 | Kein Input / leerer Input | → Fehlermeldung: "Bitte spec.md oder Requirements übergeben" |
 | specforge.json fehlt | → Standard-Profil anwenden, Hinweis ausgeben |
 | Profil-Wechsel mid-session | → Review mit neuem Profil-Scope wiederholen |
-| Input ohne EARS-Format | → Ebene 1 RQ-03 als MAJOR markieren, Reformulierung vorschlagen |
+| Input ohne EARS-Format | → Ebene 1 RQ-03 als F4 markieren, Reformulierung vorschlagen |
 | Fehlende Referenzdateien | → Klare Fehlermeldung: "[Datei] nicht gefunden — Prüfpunkt übersprungen, als FAIL gewertet" |
 | Mixed-Language Input | → Sprachverhalten gemäß Orchestrator (DE/EN nachfragen) |
 | Widersprüchliche Anforderungen | → Als AP-03 (Implizite Annahmen) + eigenständiges Finding dokumentieren |

--- a/references/08-management.md
+++ b/references/08-management.md
@@ -24,13 +24,13 @@ Constitution → GP → spec.md → Clarifications → Stories → ACs
 
 | Prüfpunkt | Was wird geprüft | Schweregrad bei Lücke |
 |-----------|-----------------|----------------------|
-| TM-01 | Jede Story hat Spec-Referenz (GP-02) | BLOCKER |
-| TM-02 | Jeder Task hat Story-Referenz | MAJOR (AP-07: Orphan Artifact) |
-| TM-03 | Jede Story hat ≥2 Gherkin-ACs | MAJOR (AP-06) |
-| TM-04 | Jede modulübergreifende Entscheidung hat ADR (GP-03) | MAJOR |
-| TM-05 | Tasks mit 5+ Dateien haben ExecPlan (GP-04) | MAJOR |
-| TM-06 | Constitution referenziert aktive GPs laut Profil | MINOR |
-| TM-07 | ARCHITECTURE.md enthält aktuelle Codemap | MINOR |
+| TM-01 | Jede Story hat Spec-Referenz (GP-02) | F4 |
+| TM-02 | Jeder Task hat Story-Referenz | F3 (AP-07: Orphan Artifact) |
+| TM-03 | Jede Story hat ≥2 Gherkin-ACs | F4 (Gate G1) |
+| TM-04 | Jede modulübergreifende Entscheidung hat ADR (GP-03) | F3 (KRITIS: F4) |
+| TM-05 | Tasks mit 5+ Dateien haben ExecPlan (GP-04) | F2 |
+| TM-06 | Constitution referenziert aktive GPs laut Profil | F4 (Gate G0) |
+| TM-07 | ARCHITECTURE.md enthält aktuelle Codemap | F3 (Gate G5) |
 
 **Output:**
 ```markdown
@@ -41,8 +41,8 @@ Constitution → GP → spec.md → Clarifications → Stories → ACs
 | Quelle | Ziel | Status | Lücke | Schweregrad |
 |--------|------|--------|-------|------------|
 | spec.md SF-FUNC-001 | Task T-001 | ✅ Verknüpft | — | — |
-| spec.md SF-SEC-003 | — | ❌ Kein Task | Orphan Spec | MAJOR |
-| Task T-005 | — | ❌ Keine Story | Orphan Task | MAJOR |
+| spec.md SF-SEC-003 | — | ❌ Kein Task | Orphan Spec | F3 |
+| Task T-005 | — | ❌ Keine Story | Orphan Task | F3 |
 
 **Abdeckung:** [X/Y] Spec-Einträge mit Task (Z%)
 **GP-02 Compliance:** [PASS / FAIL]
@@ -54,12 +54,12 @@ Prüft ob die 8-Schritt-Kette (→ `references/conventions/spec-first-chain.md`)
 
 | Prüfpunkt | Was wird geprüft | Schweregrad |
 |-----------|-----------------|------------|
-| SFC-01 | Spec-Update vor Code (Schritt 1, GP-02) | BLOCKER |
-| SFC-02 | Schema-Update bei API-Änderung (Schritt 2) | MAJOR |
-| SFC-03 | Fixture-Update bei Schema-Änderung (Schritt 3, GP-01) | MAJOR |
-| SFC-04 | Contract Tests ausgeführt (Schritt 6) | MAJOR |
-| SFC-05 | Breaking Changes dokumentiert (Schritt 7) | MAJOR |
-| SFC-06 | ARCHITECTURE.md aktuell (Schritt 8) | MINOR |
+| SFC-01 | Spec-Update vor Code (Schritt 1, GP-02) | F4 |
+| SFC-02 | Schema-Update bei API-Änderung (Schritt 2) | F3 |
+| SFC-03 | Fixture-Update bei Schema-Änderung (Schritt 3, GP-01) | F3 |
+| SFC-04 | Contract Tests ausgeführt (Schritt 6) | F3 |
+| SFC-05 | Breaking Changes dokumentiert (Schritt 7) | F3 |
+| SFC-06 | ARCHITECTURE.md aktuell (Schritt 8) | F3 (Gate G5) |
 
 **Output:**
 ```markdown
@@ -68,7 +68,7 @@ Prüft ob die 8-Schritt-Kette (→ `references/conventions/spec-first-chain.md`)
 | Task | Steps erwartet | Steps durchgeführt | Lücken | Status |
 |------|---------------|-------------------|--------|--------|
 | T-001 | 1,2,3,4,6,8 | 1,2,3,4,6,8 | — | ✅ |
-| T-002 | 1,4,5,6 | 1,4,6 | 5 (Consumer) | ⚠️ MAJOR |
+| T-002 | 1,4,5,6 | 1,4,6 | 5 (Consumer) | ⚠️ F3 |
 
 **Chain-Compliance:** [X/Y] Tasks vollständig ([Z%])
 ```
@@ -90,7 +90,7 @@ Verwaltung aller bekannten technischen Schulden in `tech-debt-tracker.md`.
 | TD-001 | [Beschreibung] | @owner | HOCH/MITTEL/NIEDRIG | [betroffene NFRs] | YYYY-MM-DD | Sprint X |
 ```
 
-**Schweregrad-Eskalation:** MINOR → MAJOR wenn Debt auf NFRs wirkt (Performance, Security, Availability).
+**F-Stufen-Eskalation:** F1 → F2, sobald die Schuld auf ein NFR wirkt (Performance, Security, Availability).
 
 ### Funktion 8.5: Spec-Diff
 
@@ -99,20 +99,20 @@ Vergleicht zwei Versionen eines Artefakts und bewertet die Änderungen:
 | Änderungstyp | Bewertung | Aktion |
 |-------------|----------|--------|
 | Neue Story hinzugefügt | Neutral | Prüfen: Hat Story ACs? EARS? |
-| Story entfernt | MAJOR | Prüfen: Begründung dokumentiert? Orphan-Check |
-| AC geändert | MINOR | Prüfen: Tests noch valide? |
-| NFR geändert | MAJOR | Prüfen: Architektur-Impact? ADR nötig? |
-| Breaking API Change | BLOCKER | Prüfen: Schritt 7 (Log Breaking Changes) |
+| Story entfernt | F3 | Prüfen: Begründung dokumentiert? Orphan-Check |
+| AC geändert | F1 | Prüfen: Tests noch valide? |
+| NFR geändert | F3 | Prüfen: Architektur-Impact? ADR nötig? |
+| Breaking API Change | F4 | Prüfen: Schritt 7 (Log Breaking Changes) |
 
 ### Funktion 8.6: Freshness Check (GP-06)
 
 | Prüfpunkt | Kriterium | Schweregrad |
 |-----------|----------|------------|
-| FR-01 | Stale Marker (TODO/TBD/FIXME) ohne Datum + Owner | MINOR |
-| FR-02 | Stale Marker älter als 14 Tage | MAJOR |
-| FR-03 | Verwaiste Schemas (Schema ohne Spec-Referenz) | MAJOR |
-| FR-04 | ARCHITECTURE.md älter als letzte strukturelle Änderung | MINOR |
-| FR-05 | spec.md Version älter als zugehörige Tasks | MAJOR |
+| FR-01 | Stale Marker (TODO/TBD/FIXME) ohne Datum + Owner | F2 (Gate G5) |
+| FR-02 | Stale Marker älter als 14 Tage | F3 |
+| FR-03 | Verwaiste Schemas (Schema ohne Spec-Referenz) | F3 (AP-07) |
+| FR-04 | ARCHITECTURE.md älter als letzte strukturelle Änderung | F3 (Gate G5) |
+| FR-05 | spec.md Version älter als zugehörige Tasks | F3 |
 
 **Freshness-Intervall nach Profil:**
 - KRITIS: Alle 14 Tage automatisch
@@ -126,10 +126,10 @@ Tracking aller bisherigen Analyze-Runs und deren Ergebnisse:
 ```markdown
 ## Analyze-Historie: [Feature-Name]
 
-| Run | Datum | GP-Score | BLOCKER | MAJOR | MINOR | Status |
-|-----|-------|---------|---------|-------|-------|--------|
-| #1 | YYYY-MM-DD | 6/10 | 2 | 5 | 3 | ❌ FAIL |
-| #2 | YYYY-MM-DD | 8/10 | 0 | 2 | 3 | ✅ PASS |
+| Run | Datum | GP-Score | F4 | F3 | F2 | F1 | Status |
+|-----|-------|---------|----|----|----|----|--------|
+| #1 | YYYY-MM-DD | 6/10 | 2 | 5 | 1 | 3 | ❌ FAIL |
+| #2 | YYYY-MM-DD | 8/10 | 0 | 2 | 1 | 3 | ⚠️ CONDITIONAL |
 
 **Trend:** GP-Score steigt / fällt / stabil
 **Fix-Zyklen bis PASS:** [Anzahl]
@@ -141,14 +141,14 @@ Folgende Regeln werden bei jeder Management-Funktion **automatisch** durchgesetz
 
 | Regel | Enforcement | Schweregrad bei Verstoß |
 |-------|-----------|------------------------|
-| Traceability-Lücken (Orphan Specs/Tasks) | Automatisch bei TM-01 bis TM-07 | BLOCKER (GP-02) / MAJOR (AP-07) |
-| Spec-First Chain Compliance | Automatisch bei SFC-01 bis SFC-06 | BLOCKER (SFC-01) / MAJOR |
-| Vage Begriffe in Spec-Diffs | Jede Änderung gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" | BLOCKER (AP-04) |
+| Traceability-Lücken (Orphan Specs/Tasks) | Automatisch bei TM-01 bis TM-07 | F4 (GP-02) / F3 (AP-07) |
+| Spec-First Chain Compliance | Automatisch bei SFC-01 bis SFC-06 | F4 (SFC-01) / F3 |
+| Vage Begriffe in Spec-Diffs | Jede Änderung gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" | F4 (AP-04) |
 | Fragen-Budget | Max. 3 Fragen pro Runde an den Nutzer | n.a. (Budget-Überschreitung = Skip) |
 | Anti-Pattern-Prüfung bei Spec-Diff | AP-01–AP-08 + custom APs aus `references/custom/anti-patterns-custom.md` bei jeder Spec-Änderung | Schweregrad laut AP-Tabelle |
-| Artefakt-Erzeugung als Datei | Alle Reports als separate .md-Dateien, nicht inline | MAJOR |
+| Artefakt-Erzeugung als Datei | Alle Reports als separate .md-Dateien, nicht inline | F2 |
 | Schweregrad-Zuweisung | Deterministisch nach enforcement-engine.md Tabelle | n.a. (systemweit) |
-| Freshness-Intervall | KRITIS: 14 Tage; Standard: bei Review; Startup: bei Bedarf | MAJOR (bei Überschreitung KRITIS) |
+| Freshness-Intervall | KRITIS: 14 Tage; Standard: bei Review; Startup: bei Bedarf | F3 (bei Überschreitung im KRITIS-Profil) |
 
 ## Erweiterbarkeit
 

--- a/references/09-discover.md
+++ b/references/09-discover.md
@@ -12,7 +12,7 @@
 
 - **KRITIS:** Beide QS-Schleifen Pflicht (keine Ausnahme); STRIDE + KRITIS-NFRs in generierter Spec; Keine offenen F4- oder F3-Befunde nach QS-2
 - **Standard:** Beide QS-Schleifen Pflicht; STRIDE für SEC-relevante Stories; F3 darf mit dokumentierter Risiko-Akzeptanz mitgenommen werden
-- **Startup:** QS-Schleife 1 (Vollständigkeit) Pflicht; QS-Schleife 2 (Stringenz) empfohlen; Soft-Findings statt Blocker
+- **Startup:** QS-Schleife 1 (Vollständigkeit) Pflicht; QS-Schleife 2 (Stringenz) empfohlen; Soft-Findings statt F4
 
 ## Ablauf (deterministisch)
 

--- a/references/09-discover.md
+++ b/references/09-discover.md
@@ -10,8 +10,8 @@
 
 ## Profil-Steuerung
 
-- **KRITIS:** Beide QS-Schleifen Pflicht (keine Ausnahme); STRIDE + KRITIS-NFRs in generierter Spec; Keine offenen BLOCKER/MAJOR nach QS-2
-- **Standard:** Beide QS-Schleifen Pflicht; STRIDE für SEC-relevante Stories; MAJOR darf dokumentiert mitgenommen werden
+- **KRITIS:** Beide QS-Schleifen Pflicht (keine Ausnahme); STRIDE + KRITIS-NFRs in generierter Spec; Keine offenen F4- oder F3-Befunde nach QS-2
+- **Standard:** Beide QS-Schleifen Pflicht; STRIDE für SEC-relevante Stories; F3 darf mit dokumentierter Risiko-Akzeptanz mitgenommen werden
 - **Startup:** QS-Schleife 1 (Vollständigkeit) Pflicht; QS-Schleife 2 (Stringenz) empfohlen; Soft-Findings statt Blocker
 
 ## Ablauf (deterministisch)
@@ -85,11 +85,11 @@ Vollwertige spec.md mit **identischem Qualitätsanspruch** wie Modus 1 (Specify)
 
 | Prüfpunkt | Was wird geprüft | Schweregrad |
 |-----------|-----------------|------------|
-| QS1-01 | Jeder API-Endpoint hat Story | MAJOR |
-| QS1-02 | Jede Business Rule hat Story | MAJOR |
-| QS1-03 | Jeder Datenfluss ist dokumentiert | MINOR |
-| QS1-04 | Alle Auth/Authz-Pfade abgebildet | MAJOR (bei KRITIS: BLOCKER) |
-| QS1-05 | Error-Handling-Pfade als Unwanted-Stories | MAJOR (AP-06) |
+| QS1-01 | Jeder API-Endpoint hat Story | F3 |
+| QS1-02 | Jede Business Rule hat Story | F3 |
+| QS1-03 | Jeder Datenfluss ist dokumentiert | F1 |
+| QS1-04 | Alle Auth/Authz-Pfade abgebildet | F3 (KRITIS: F4) |
+| QS1-05 | Error-Handling-Pfade als Unwanted-Stories | F3 (AP-06) |
 
 **Loop:** Wiederholen bis keine FEHLT-Einträge mehr vorhanden.
 
@@ -113,23 +113,23 @@ Vollwertige spec.md mit **identischem Qualitätsanspruch** wie Modus 1 (Specify)
 
 | Prüfpunkt | Was wird geprüft | Schweregrad |
 |-----------|-----------------|------------|
-| QS2-01 | Begriffe konsistent (gleicher Begriff = gleiche Bedeutung überall) | MAJOR |
-| QS2-02 | Keine widersprüchlichen Requirements | BLOCKER |
-| QS2-03 | Ist/Soll-Delta dokumentiert (was ist im Code, was fehlt) | MAJOR |
+| QS2-01 | Begriffe konsistent (gleicher Begriff = gleiche Bedeutung überall) | F3 (AP-08) |
+| QS2-02 | Keine widersprüchlichen Requirements | F4 |
+| QS2-03 | Ist/Soll-Delta dokumentiert (was ist im Code, was fehlt) | F3 |
 | QS2-04 | GP-Compliance laut Profil | Schweregrad laut GP |
-| QS2-05 | EARS-Pattern korrekt gewählt (deterministisch nach Entscheidungsbaum) | MINOR |
-| QS2-06 | Keine verwaisten Stories (Story ohne Code-Evidenz = Soll, kennzeichnen) | MINOR |
+| QS2-05 | EARS-Pattern korrekt gewählt (deterministisch nach Entscheidungsbaum) | F1 |
+| QS2-06 | Keine verwaisten Stories (Story ohne Code-Evidenz = Soll, kennzeichnen) | F1 |
 
-**Loop:** Wiederholen bis keine BLOCKER/MAJOR-Findings (KRITIS/Standard) bzw. keine BLOCKER (Startup).
+**Loop:** Wiederholen bis keine F4- oder F3-Befunde offen sind (KRITIS/Standard) bzw. keine F4-Befunde (Startup).
 
 **Output pro Iteration:**
 ```markdown
 ## QS-2 Konsistenz: Iteration [N]
 | # | Prüfpunkt | Status | Schweregrad | Befund | Fix |
 |---|-----------|--------|------------|--------|-----|
-| QS2-01 | Begriffskonsistenz | ✅/❌ | — / MAJOR | [Befund] | [Fix] |
+| QS2-01 | Begriffskonsistenz | ✅/❌ | — / F3 | [Befund] | [Fix] |
 
-**Offene Findings:** BLOCKER: [X] | MAJOR: [Y] | MINOR: [Z]
+**Offene Befunde:** F4: [W] | F3: [X] | F2: [Y] | F1: [Z]
 **Status:** [PASS / Nächste Iteration nötig]
 ```
 
@@ -146,11 +146,11 @@ Vollwertige spec.md mit **identischem Qualitätsanspruch** wie Modus 1 (Specify)
 
 | Gate | Prüfung | Schweregrad bei Fail |
 |------|---------|---------------------|
-| G0-RE | Discovery-Protokoll erzeugt? Quellen dokumentiert? | BLOCKER |
-| G1-RE | 5W-Analyse komplett? Alle 5 Dimensionen mit Konfidenz? | BLOCKER |
-| G2-RE | spec.md erzeugt? EARS + Gherkin? Qualität = Forward-Path? | BLOCKER |
-| G3-RE | QS-1 bestanden (Vollständigkeit)? QS-2 bestanden (Konsistenz)? | BLOCKER |
-| G4-RE | Finalisierung — spec.md konsistent, Ist/Soll-Delta dokumentiert? | BLOCKER |
+| G0-RE | Discovery-Protokoll erzeugt? Quellen dokumentiert? | F4 |
+| G1-RE | 5W-Analyse komplett? Alle 5 Dimensionen mit Konfidenz? | F4 |
+| G2-RE | spec.md erzeugt? EARS + Gherkin? Qualität = Forward-Path? | F4 |
+| G3-RE | QS-1 bestanden (Vollständigkeit)? QS-2 bestanden (Konsistenz)? | F4 |
+| G4-RE | Finalisierung — spec.md konsistent, Ist/Soll-Delta dokumentiert? | F4 |
 
 Nach G4-RE: Übergang in Forward-Path ab G2 (Clarify) oder G3 (Plan).
 
@@ -158,13 +158,13 @@ Nach G4-RE: Übergang in Forward-Path ab G2 (Clarify) oder G3 (Plan).
 
 | Regel | Enforcement | Schweregrad |
 |-------|-----------|------------|
-| Vage Begriffe aus Blocklist | Jede erzeugte Story gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | BLOCKER |
+| Vage Begriffe aus Blocklist | Jede erzeugte Story gegen Blocklist prüfen: "schnell", "viele", "einfach", "skalierbar", "sicher", "zuverlässig" → AP-04 | F4 |
 | Fragen-Budget | Stakeholder-Befragung: max. 5 Fragen/Runde; sonstige Interaktion: max. 3 Fragen/Runde | n.a. |
 | Anti-Pattern-Prüfung | AP-01–AP-08 + custom APs bei jeder Story-Erzeugung in Phase 9c | Schweregrad laut AP-Tabelle |
-| EARS-Pflicht | Jede Story hat explizit benanntes Pattern (wie Forward-Path) | MAJOR |
-| Gherkin-Minimum | ≥2 Szenarien pro Story (Happy Path + Fehlerfall) | MAJOR (AP-06) |
-| QS-Schleifen nicht überspringbar | KRITIS: beide Pflicht; Standard: beide Pflicht; Startup: QS-1 Pflicht | BLOCKER bei Skip |
-| Artefakt-Erzeugung als Datei | Alle Artefakte als separate .md-Dateien, nicht inline | MAJOR |
+| EARS-Pflicht | Jede Story hat explizit benanntes Pattern (wie Forward-Path) | F4 |
+| Gherkin-Minimum | ≥2 Szenarien pro Story (Gate G1) | F4 |
+| QS-Schleifen nicht überspringbar | KRITIS: beide Pflicht; Standard: beide Pflicht; Startup: QS-1 Pflicht | F4 bei Skip ohne F5-Protokoll |
+| Artefakt-Erzeugung als Datei | Alle Artefakte als separate .md-Dateien, nicht inline | F2 |
 | Schweregrad-Zuweisung | Deterministisch nach enforcement-engine.md | n.a. |
 
 ## Erweiterbarkeit
@@ -215,6 +215,6 @@ Nach G4-RE: Übergang in Forward-Path ab G2 (Clarify) oder G3 (Plan).
 ## Pflicht: Beide QS-Schleifen durchlaufen — kein Abkürzen.
 
 QS-Schleifen-Intensität richtet sich nach Profil:
-- **KRITIS:** Beide Schleifen strikt, keine offenen BLOCKER/MAJOR nach Abschluss
-- **Standard:** Beide Schleifen, MAJOR darf dokumentiert mitgenommen werden
+- **KRITIS:** Beide Schleifen strikt, keine offenen F4- oder F3-Befunde nach Abschluss
+- **Standard:** Beide Schleifen, F3 darf mit dokumentierter Risiko-Akzeptanz mitgenommen werden
 - **Startup:** Schleife 1 (Vollständigkeit) Pflicht, Schleife 2 (Stringenz) empfohlen

--- a/references/checklists/golden-principles.md
+++ b/references/checklists/golden-principles.md
@@ -44,14 +44,14 @@ Die F-Stufen unten sind die Default-Werte. Wo ein Gate aus `references/enforceme
 **Datum:** [YYYY-MM-DD]
 ## Kontext — ## Entscheidung — ## Konsequenzen — ## Alternativen
 ```
-**F-Stufe:** F3 (KRITIS: F4) — Gate G3 führt ADRs profilabhängig
+**F-Stufe:** F3 (KRITIS: F4), weil Gate G3 ADRs profilabhängig führt
 
 ## GP-04: ExecPlan-Pflicht
 **Regel:** Tasks mit 5+ Dateiänderungen brauchen EP-*.md in `plans/active/`.
 **Enforcement:** Tasks-Phase Gate — Dateizählung pro Task.
 **Verstoß-Beispiel:** Task ändert 12 Dateien über 3 Module ohne ExecPlan.
 **ExecPlan-Format:** Änderungsreihenfolge, Abhängigkeiten, Rollback-Strategie, Checkpoint.
-**F-Stufe:** F2 — Gate G3
+**F-Stufe:** F2 (Gate G3)
 
 ## GP-05: Invariant-Traceability
 **Regel:** Tests referenzieren Invariant-IDs aus `ARCHITECTURE.md`.
@@ -63,12 +63,12 @@ Die F-Stufen unten sind die Default-Werte. Wo ein Gate aus `references/enforceme
 **Regel:** TODO/TBD/FIXME brauchen Datum + Owner. Max. 14 Tage.
 **Korrektes Format:** `// TODO(2025-10-01, @owner): Beschreibung — Ticket: PROJ-123`
 **Verstoß-Beispiel:** `// TODO: Caching implementieren` seit 3 Monaten.
-**F-Stufe:** F2 (Gate G5) — F3, sobald die 14-Tage-Frist überschritten ist
+**F-Stufe:** F2 (Gate G5), ab Überschreitung der 14-Tage-Frist F3
 
 ## GP-07: Dokument-Platzierung
 **Regel:** Alle Artefakte in Convention-Verzeichnissen (→ folder-convention.md).
 **Verstoß-Beispiel:** ADR in `docs/decisions/` statt `specs/decisions/`.
-**F-Stufe:** F2 — Gate G0 führt den Folder-Convention-Check
+**F-Stufe:** F2, weil Gate G0 den Folder-Convention-Check führt
 
 ## GP-08: Prinzip-Unverletzlichkeit
 **Regel:** Verstöße gegen Golden Principles blockieren bis zur Auflösung.
@@ -84,7 +84,7 @@ Die F-Stufen unten sind die Default-Werte. Wo ein Gate aus `references/enforceme
 ## GP-10: Schulden-Tracking
 **Regel:** Jede Tech-Debt in `tech-debt-tracker.md` mit ID + Owner.
 **Format:** `| TD-NNN | Beschreibung | Owner | Priorität | Auswirkung | Erstellt | Ziel-Sprint |`
-**F-Stufe:** F1 — F2, sobald die Schuld auf ein NFR wirkt (Performance, Security, Availability)
+**F-Stufe:** F1, bei Wirkung auf ein NFR (Performance, Security, Availability) F2
 
 ---
 

--- a/references/checklists/golden-principles.md
+++ b/references/checklists/golden-principles.md
@@ -2,6 +2,8 @@
 
 Jede constitution.md enthält diese Prinzipien als enforceable Regeln. SpecForge prüft jede Spezifikation dagegen.
 
+Die F-Stufen unten sind die Default-Werte. Wo ein Gate aus `references/enforcement/enforcement-engine.md` denselben Prüfpunkt führt, gilt der Gate-Wert; die Quelle steht jeweils daneben. Projektspezifische Abweichungen gehören in `checks_config` der specforge.json, nicht in dieses Dokument.
+
 | ID | Prinzip | Regel | Enforcement |
 |----|---------|-------|-------------|
 | GP-01 | Schema-Hygiene | Matching Fixtures + Testabdeckung für alle API-Contracts | Spec-First Chain Schritt 2+3+6 |
@@ -22,14 +24,14 @@ Jede constitution.md enthält diese Prinzipien als enforceable Regeln. SpecForge
 **Enforcement:** Spec-First Chain Schritte 2+3+6.
 **Verstoß-Beispiel:** API liefert Feld `created_at` zurück, das im Schema nicht definiert ist.
 **Prüfung:** Schema vorhanden? Fixture vorhanden? Contract Tests validieren Schema + Fixture?
-**Schweregrad:** MAJOR
+**F-Stufe:** F3
 
 ## GP-02: Spec-before-Code
 **Regel:** Keine Implementierung ohne Spec-Eintrag in `specs/`.
 **Enforcement:** Spec-Phase Gate.
 **Verstoß-Beispiel:** Neuer Endpoint implementiert, der in keiner spec.md beschrieben ist.
 **Prüfung:** Korrespondierende Story? Story vor Implementierung geschrieben? ACs vor Tests?
-**Schweregrad:** BLOCKER
+**F-Stufe:** F4
 
 ## GP-03: ADR-Disziplin
 **Regel:** Modulübergreifende Entscheidungen brauchen ADR in `specs/decisions/`.
@@ -42,47 +44,47 @@ Jede constitution.md enthält diese Prinzipien als enforceable Regeln. SpecForge
 **Datum:** [YYYY-MM-DD]
 ## Kontext — ## Entscheidung — ## Konsequenzen — ## Alternativen
 ```
-**Schweregrad:** BLOCKER
+**F-Stufe:** F3 (KRITIS: F4) — Gate G3 führt ADRs profilabhängig
 
 ## GP-04: ExecPlan-Pflicht
 **Regel:** Tasks mit 5+ Dateiänderungen brauchen EP-*.md in `plans/active/`.
 **Enforcement:** Tasks-Phase Gate — Dateizählung pro Task.
 **Verstoß-Beispiel:** Task ändert 12 Dateien über 3 Module ohne ExecPlan.
 **ExecPlan-Format:** Änderungsreihenfolge, Abhängigkeiten, Rollback-Strategie, Checkpoint.
-**Schweregrad:** MAJOR
+**F-Stufe:** F2 — Gate G3
 
 ## GP-05: Invariant-Traceability
 **Regel:** Tests referenzieren Invariant-IDs aus `ARCHITECTURE.md`.
 **Enforcement:** Traceability Matrix.
 **Verstoß-Beispiel:** Invariante "max. 3 aktive Sessions" ohne Test-Referenz.
-**Schweregrad:** MAJOR
+**F-Stufe:** F2
 
 ## GP-06: Keine stale Marker
 **Regel:** TODO/TBD/FIXME brauchen Datum + Owner. Max. 14 Tage.
 **Korrektes Format:** `// TODO(2025-10-01, @owner): Beschreibung — Ticket: PROJ-123`
 **Verstoß-Beispiel:** `// TODO: Caching implementieren` seit 3 Monaten.
-**Schweregrad:** MINOR (wird MAJOR nach 30 Tagen)
+**F-Stufe:** F2 (Gate G5) — F3, sobald die 14-Tage-Frist überschritten ist
 
 ## GP-07: Dokument-Platzierung
 **Regel:** Alle Artefakte in Convention-Verzeichnissen (→ folder-convention.md).
 **Verstoß-Beispiel:** ADR in `docs/decisions/` statt `specs/decisions/`.
-**Schweregrad:** MINOR
+**F-Stufe:** F2 — Gate G0 führt den Folder-Convention-Check
 
 ## GP-08: Prinzip-Unverletzlichkeit
 **Regel:** Verstöße gegen Golden Principles blockieren bis zur Auflösung.
 **Meta-Prinzip:** Sichert alle anderen GPs ab.
-**Verstoß-Beispiel:** BLOCKER-Verstoß gegen GP-02 wird ignoriert.
-**Schweregrad:** Meta — sichert alle anderen GPs ab.
+**Verstoß-Beispiel:** F4-Verstoß gegen GP-02 wird ignoriert.
+**F-Stufe:** Meta — sichert alle anderen GPs ab.
 
 ## GP-09: Abhängigkeitsrichtung
 **Regel:** Consumer kennt Provider-Interface, nicht Provider-Interna.
 **Verstoß-Beispiel:** Frontend importiert Backend-DB-Entity direkt statt über API-Contract.
-**Schweregrad:** MAJOR
+**F-Stufe:** F3
 
 ## GP-10: Schulden-Tracking
 **Regel:** Jede Tech-Debt in `tech-debt-tracker.md` mit ID + Owner.
 **Format:** `| TD-NNN | Beschreibung | Owner | Priorität | Auswirkung | Erstellt | Ziel-Sprint |`
-**Schweregrad:** MINOR (wird MAJOR wenn Debt auf NFRs wirkt)
+**F-Stufe:** F1 — F2, sobald die Schuld auf ein NFR wirkt (Performance, Security, Availability)
 
 ---
 

--- a/references/checklists/kritis-nfr.md
+++ b/references/checklists/kritis-nfr.md
@@ -97,10 +97,7 @@ Automatische Prüfliste für nicht-funktionale Anforderungen in KRITIS-reguliert
 
 ### Legacy-Kompatibilität
 
-Für Projekte die noch mit dem bisherigen Schweregrad-System arbeiten, gilt folgendes Mapping:
-
-| Legacy-Schweregrad | F-Stufen-Äquivalent | Gate-Ergebnis |
-|--------------------|---------------------|---------------|
-| BLOCKER | F4 | FAIL |
-| MAJOR | F3 | CONDITIONAL |
-| MINOR | F1 | INFO |
+F-Stufen sind das einzige Schweregrad-Vokabular dieser Checkliste und aller Module. Das
+Eingangs-Mapping für alte `specforge.json`-Dateien ohne `severity_model` steht an genau einer
+Stelle: `references/enforcement/enforcement-engine.md`, Abschnitt "Abwärtskompatibilität
+(Legacy-Mapping)". Dort und nur dort ist es normativ.

--- a/references/checklists/stride-guide.md
+++ b/references/checklists/stride-guide.md
@@ -105,7 +105,7 @@ Threat-Modeling-Framework für security-relevante Requirements. Bei jeder securi
 1. Bei jeder Story mit SEC-NFR oder expliziter Anfrage
 2. **Alle 6 Kategorien werden geprüft** — auch wenn nur einzelne offensichtlich relevant sind
 3. Output: Tabelle im spec.md mit Bewertung pro Kategorie
-4. Fehlende STRIDE-Analyse für security-relevante Stories = BLOCKER in Analyze
+4. Fehlende STRIDE-Analyse für security-relevante Stories = F3 in Analyze (`stride_complete`; regulated_entity F4, advisory F1 laut `checks_config`)
 5. STRIDE wird bei Spec-Updates wiederholt, nicht nur einmalig
 
 ## Output-Format

--- a/references/conventions/rpi-framework-evaluation.md
+++ b/references/conventions/rpi-framework-evaluation.md
@@ -41,7 +41,7 @@ Ein LLM-Prompt (Skill) ist ein "weicher" Vertrag – der Agent kann ihn im Eifer
 
 1. **Der Plan Fidelity Diff-Checker:**
    * *Warum:* LLMs sind schlecht darin, exakte Datei-Diffs gegen eine Markdown-Liste zu validieren.
-   * *Plugin-Idee:* Ein Hook in der Ausführungs-Engine. Bevor eine Datei via `Write/Edit` geschrieben wird, prüft ein hart codiertes Plugin (AST-Parser oder Regex), ob diese Datei explizit in der `plan.md` freigegeben wurde. Wenn nicht → harter System-Blocker.
+   * *Plugin-Idee:* Ein Hook in der Ausführungs-Engine. Bevor eine Datei via `Write/Edit` geschrieben wird, prüft ein hart codiertes Plugin (AST-Parser oder Regex), ob diese Datei explizit in der `plan.md` freigegeben wurde. Wenn nicht → harter System-Stopp.
 2. **State Machine für die "Prompt Diet" (Phasen-Orchestrierung):**
    * *Warum:* Dem LLM zu sagen "Bitte stoppe hier und warte auf den User" ist extrem fehleranfällig.
    * *Plugin-Idee:* Ein SpecForge-Plugin orchestriert die Phasen (Research → Outline → Plan → Implement). Das Plugin injiziert dem Agenten jeweils *nur* den Prompt für die aktuelle Phase. Der Agent kann technisch gar nicht in die nächste Phase springen, bis der Nutzer "Approve Outline" klickt.

--- a/references/enforcement/enforcement-engine.md
+++ b/references/enforcement/enforcement-engine.md
@@ -224,9 +224,14 @@ Jeder F5-Befund (nicht anwendbar) erfordert eine dokumentierte Begründung. Bei 
 **Risiko:** [Beschreibung des Risikos bei Akzeptanz]
 **Akzeptiert durch:** [Name/Rolle des Leitungsorgans]
 **Kompensation:** [Geplante Maßnahmen zur Risikoreduktion]
-**Frist:** [Bis wann muss der Mangel behoben sein?]
+**Frist:** [YYYY-MM-DD, bis wann der Mangel behoben sein muss]
 **Datum:** [YYYY-MM-DD]
 ```
+
+Alle acht Felder sind Pflicht. Ein Block, dem eines fehlt, ist keine Akzeptanz, sondern eine
+Notiz. Frist und Datum tragen ein Datum im Format `YYYY-MM-DD`; eine abgelaufene Frist beendet
+die Akzeptanz, ohne dass jemand sie zurückziehen muss. `specforge check --risiko-akzeptanz`
+prüft genau das und meldet jeden Block, der die Bedingungen nicht erfüllt.
 
 ---
 

--- a/references/enforcement/enforcement-engine.md
+++ b/references/enforcement/enforcement-engine.md
@@ -62,8 +62,8 @@ gemeint war.
 | MAJOR | F3 |
 | MINOR | F1 |
 
-`scripts/check-severity-dialect.py` setzt diese Regel maschinell durch: außerhalb dieses
-Abschnitts darf im Payload kein BLOCKER, MAJOR oder MINOR mehr stehen.
+Das Repository setzt diese Regel in seiner CI maschinell durch: außerhalb dieses Abschnitts
+darf im Payload keiner der drei Werte mehr stehen.
 
 ### Perspektivenabhängige F-Stufen
 

--- a/references/enforcement/enforcement-engine.md
+++ b/references/enforcement/enforcement-engine.md
@@ -41,7 +41,17 @@ Das F-Stufen-System ersetzt das bisherige binäre `required: true/false`. Die Kl
 
 ### Abwärtskompatibilität (Legacy-Mapping)
 
-Projekte ohne `severity_model` in specforge.json nutzen weiterhin Boolean-Logik. Die interne Zuordnung:
+Dieser Abschnitt ist die einzige Stelle im Payload, an der die Werte BLOCKER, MAJOR und MINOR
+noch eine Bedeutung haben. Er hat genau einen Zweck: eine `specforge.json` einzulesen, die noch
+kein `severity_model` führt oder in `checks_config` Legacy-Werte trägt. Beim Einlesen werden sie
+einmal übersetzt; ab da rechnet die Engine ausschließlich mit F-Stufen.
+
+Nicht zulässig ist die Verwendung dieser Werte in Modulprosa, in Checklisten, in Templates, in
+Gate-Ausgaben oder in Befundtexten. Wer eine Regel neu schreibt, vergibt eine F-Stufe. Das Mapping
+ist verlustbehaftet: F0, F2 und F5 sind über den Legacy-Weg nicht erreichbar, obwohl der Payload
+sie braucht. Ein Prüfpunkt, der pauschal über MAJOR übersetzt wird, landet auf F3 und verlangt
+damit eine Risiko-Akzeptanz durch das Leitungsorgan, wo oft ein Pflicht-Task vor Go-Live (F2)
+gemeint war.
 
 | Legacy-Wert | F-Stufen-Äquivalent |
 |-------------|---------------------|
@@ -51,6 +61,9 @@ Projekte ohne `severity_model` in specforge.json nutzen weiterhin Boolean-Logik.
 | BLOCKER (Anti-Pattern/Schweregrad) | F4 |
 | MAJOR | F3 |
 | MINOR | F1 |
+
+`scripts/check-severity-dialect.py` setzt diese Regel maschinell durch: außerhalb dieses
+Abschnitts darf im Payload kein BLOCKER, MAJOR oder MINOR mehr stehen.
 
 ### Perspektivenabhängige F-Stufen
 
@@ -228,7 +241,7 @@ Bei jeder Story-Erzeugung und jedem Review automatisch prüfen:
 | AP-03 | Implizite Annahmen | Unausgesprochene Voraussetzungen | Fehlende `[Annahme: ...]`-Marker | F3 |
 | AP-04 | Vage Quantifizierung | Nicht messbare Anforderungen | "schnell", "viele", "einfach" etc. | F4 |
 | AP-05 | Scope Creep | Schleichende Erweiterung ohne Spec-Update | Tasks ohne Spec-Referenz (GP-02) | F4 |
-| AP-06 | Missing Negative | Nur Happy Path, keine Fehlerfälle | <2 Gherkin-Szenarien, kein Unwanted-Pattern | F3 |
+| AP-06 | Missing Negative | Nur Happy Path, keine Fehlerfälle | Szenarien vorhanden, aber kein Fehlerfall und kein Unwanted-Pattern | F3 |
 | AP-07 | Orphan Artifact | Artefakt ohne Bezug zum Workflow | Task ohne Story, Story ohne Spec | F3 |
 | AP-08 | SOPHIST-Verletzung | Sprachliche Mehrdeutigkeit oder Unvollständigkeit | Passiv ohne Akteur, Negation statt Positivaussage, optionale Formulierung ohne Bedingung, generische Begriffe ("das System", "der Nutzer") | F3 |
 
@@ -247,7 +260,10 @@ AP-08 erkennt sprachliche Anti-Patterns, die über vage Quantifizierung (AP-04) 
 
 **Abgrenzung AP-04 vs. AP-08:** AP-04 erkennt nicht messbare Quantifizierungen ("schnell", "viele"). AP-08 erkennt sprachliche Strukturprobleme (Passiv, Negation, Generik). Beide können gleichzeitig zutreffen — ein und dasselbe Requirement kann sowohl AP-04 als auch AP-08 verletzen.
 
-**Legacy-Mapping:** BLOCKER → F4, MAJOR → F3, MINOR → F1
+**Abgrenzung AP-06 vs. Gherkin-Minimum:** Die Mindestanzahl von zwei Szenarien je Story ist ein
+eigener Gate-Prüfpunkt (G1, F4) und blockiert das Gate. AP-06 greift eine Stufe darüber: Szenarien
+sind vorhanden, decken aber nur den Happy Path ab. Weniger als zwei Szenarien sind also F4, nicht
+F3.
 
 ---
 

--- a/references/templates/constitution-template.md
+++ b/references/templates/constitution-template.md
@@ -99,10 +99,10 @@ Eine Spezifikation gilt als "Done", wenn:
 - [ ] Jede Story hat ≥2 Gherkin-Szenarien mit konkreten Testdaten
 - [ ] NFR-Kategorien vollständig gegen KRITIS-Checkliste geprüft
 - [ ] STRIDE für alle security-relevanten Stories durchgeführt
-- [ ] Clarifications-Abschnitt abgeschlossen (keine offenen BLOCKER)
+- [ ] Clarifications-Abschnitt abgeschlossen (keine offenen F4-Fragen)
 - [ ] GP-Compliance pro Story dokumentiert
 - [ ] Review & Acceptance Checklist vollständig ausgefüllt
-- [ ] Analyze-Report ohne BLOCKER-Befunde
+- [ ] Analyze-Report ohne F4-Befunde
 
 ### Definition of Done (Implementierungs-Ebene)
 

--- a/references/templates/spec-template.md
+++ b/references/templates/spec-template.md
@@ -87,7 +87,7 @@ Scenario: [Edge Case / Fehlerfall]
 - Blockiert: [SF-XXX-NNN]
 
 #### Offene Fragen
-- [Frage mit Schweregrad: BLOCKER | MAJOR | MINOR]
+- [Frage mit F-Stufe: F4 | F3 | F2 | F1]
 
 #### GP-Compliance
 - [Betroffene Golden Principles mit Status]
@@ -151,7 +151,7 @@ Dieses Modell beschreibt die Fachdomäne in der Sprache der Stakeholder. Technis
 - [ ] NFR-Kategorien vollständig geprüft
 - [ ] STRIDE für security-relevante Stories durchgeführt
 - [ ] Keine vagen Begriffe ohne Quantifizierung
-- [ ] Keine offenen BLOCKER-Fragen
+- [ ] Keine offenen F4-Fragen
 - [ ] Constitution-Compliance geprüft
 - [ ] GP-Compliance pro Story dokumentiert
 - [ ] Abhängigkeiten zwischen Stories dokumentiert

--- a/scripts/check-linter-fixtures.py
+++ b/scripts/check-linter-fixtures.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Faehrt specforge check ueber die Fixtures und prueft Exit-Code und Befunde.
+
+Die Unit-Tests pruefen die Bausteine des Linters. Dieses Skript prueft den
+Aufruf, so wie ihn eine fremde Pipeline macht: ueber die Kommandozeile, mit
+dem Exit-Code als Ergebnis. Beides zusammen deckt den Weg vom Prozessaufruf
+bis zum Befund ab.
+
+Erwartet wird je Fixture ein Exit-Code und die Menge der Befunde als Paare
+aus Pruefpunkt und F-Stufe. Eine Abweichung in beide Richtungen ist ein
+Fehler: ein Befund zu wenig genauso wie einer zu viel.
+
+Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+# Fixture -> (Exit-Code, zusaetzliche Argumente, [(Pruefpunkt, F-Stufe), ...])
+ERWARTUNG = {
+    "01-valide": (0, [], []),
+    "02-gherkin-fehlt": (1, [], [
+        ("gherkin_minimum", "F4"),
+    ]),
+    "03-vage-begriffe": (1, [], [
+        ("vague_terms", "F4"),
+        ("vague_terms", "F4"),
+        ("vague_terms", "F4"),
+        ("sophist", "F3"),
+    ]),
+    "03-vage-begriffe-nach-clarify": (1, ["--nach-clarify"], [
+        ("vague_terms", "F4"),
+        ("vague_terms", "F4"),
+        ("vague_terms", "F4"),
+        ("sophist", "F3"),
+        ("open_marker", "F3"),
+        ("open_marker", "F3"),
+    ]),
+    "04-orphan-task": (2, [], [
+        ("orphan_task", "F3"),
+    ]),
+}
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def fixture_dir(root, name):
+    """'03-vage-begriffe-nach-clarify' zeigt auf dasselbe Verzeichnis."""
+    base = name.replace("-nach-clarify", "")
+    return os.path.join(root, "tests", "fixtures", base)
+
+
+def run(root, name, extra):
+    command = [sys.executable, os.path.join(root, "cli", "specforge"),
+               "check", fixture_dir(root, name), "--json"] + extra
+    process = subprocess.run(command, capture_output=True, text=True)
+    return process
+
+
+def main():
+    root = repo_root()
+    errors = []
+    report = []
+
+    for name in sorted(ERWARTUNG):
+        expected_code, extra, expected = ERWARTUNG[name]
+        process = run(root, name, extra)
+        if process.returncode != expected_code:
+            errors.append("%s: Exit-Code %d statt %d\n%s"
+                          % (name, process.returncode, expected_code,
+                             process.stderr.strip()))
+            continue
+        try:
+            data = json.loads(process.stdout)
+        except ValueError as error:
+            errors.append("%s: Ausgabe ist kein JSON (%s)" % (name, error))
+            continue
+        found = sorted((item["check"], item["severity"])
+                       for item in data["findings"])
+        if found != sorted(expected):
+            errors.append("%s: Befunde %s statt %s"
+                          % (name, found, sorted(expected)))
+            continue
+        report.append((name, expected_code, len(found)))
+
+    print("Geprueft: %d Fixture-Laeufe" % len(ERWARTUNG))
+    for name, code, count in report:
+        print("  %-34s Exit %d, %d Befund(e)" % (name, code, count))
+
+    if errors:
+        print("")
+        print("FEHLER (%d):" % len(errors))
+        for message in errors:
+            print("  - %s" % message)
+        return 1
+
+    print("")
+    print("OK: specforge check meldet die erwarteten F-Stufen und "
+          "Exit-Codes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-linter-fixtures.py
+++ b/scripts/check-linter-fixtures.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 
 # Fixture -> (Exit-Code, zusaetzliche Argumente, [(Pruefpunkt, F-Stufe), ...])
+# {fixture} in den Argumenten wird durch das Fixture-Verzeichnis ersetzt.
 ERWARTUNG = {
     "01-valide": (0, [], []),
     "02-gherkin-fehlt": (1, [], [
@@ -42,6 +43,22 @@ ERWARTUNG = {
     "04-orphan-task": (2, [], [
         ("orphan_task", "F3"),
     ]),
+    "04-orphan-task-akzeptiert": (0, [
+        "--risiko-akzeptanz", "{fixture}/risiko-akzeptanz.md"], [
+        ("orphan_task", "F3"),
+    ]),
+    "04-orphan-task-abgelehnt": (2, [
+        "--risiko-akzeptanz", "{fixture}/risiko-abgelehnt.md"], [
+        ("orphan_task", "F3"),
+    ]),
+    "04-orphan-task-unvollstaendig": (2, [
+        "--risiko-akzeptanz", "{fixture}/risiko-unvollstaendig.md"], [
+        ("orphan_task", "F3"),
+    ]),
+    "04-orphan-task-abgelaufen": (2, [
+        "--risiko-akzeptanz", "{fixture}/risiko-abgelaufen.md"], [
+        ("orphan_task", "F3"),
+    ]),
     "05-leer": (1, [], [
         ("no_stories", "F4"),
     ]),
@@ -55,15 +72,24 @@ def repo_root():
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+# Varianten desselben Fixtures: anderer Aufruf, dasselbe Verzeichnis.
+VARIANTEN = ("-nach-clarify", "-akzeptiert", "-abgelehnt",
+             "-unvollstaendig", "-abgelaufen")
+
+
 def fixture_dir(root, name):
     """'03-vage-begriffe-nach-clarify' zeigt auf dasselbe Verzeichnis."""
-    base = name.replace("-nach-clarify", "")
+    base = name
+    for suffix in VARIANTEN:
+        base = base.replace(suffix, "")
     return os.path.join(root, "tests", "fixtures", base)
 
 
 def run(root, name, extra):
+    directory = fixture_dir(root, name)
+    arguments = [item.replace("{fixture}", directory) for item in extra]
     command = [sys.executable, os.path.join(root, "cli", "specforge"),
-               "check", fixture_dir(root, name), "--json"] + extra
+               "check", directory, "--json"] + arguments
     process = subprocess.run(command, capture_output=True, text=True)
     return process
 

--- a/scripts/check-linter-fixtures.py
+++ b/scripts/check-linter-fixtures.py
@@ -42,6 +42,12 @@ ERWARTUNG = {
     "04-orphan-task": (2, [], [
         ("orphan_task", "F3"),
     ]),
+    "05-leer": (1, [], [
+        ("no_stories", "F4"),
+    ]),
+    "06-formatfremd": (1, [], [
+        ("no_stories", "F4"),
+    ]),
 }
 
 

--- a/scripts/check-package.py
+++ b/scripts/check-package.py
@@ -61,7 +61,8 @@ JUNK_SUFFIXES = (".swp", ".swo", "~", ".orig", ".rej")
 FORBIDDEN_FRAGMENTS = (
     ".git/", ".github", ".gitignore", "index.html", "course.html",
     "examples/", "docs/", "scripts/", "packaging/", "contributing",
-    "changelog", ".ds_store", "thumbs.db", ".env", "id_rsa", "id_ed25519",
+    "changelog", "cli/", "evals/", "tests/", ".py",
+    ".ds_store", "thumbs.db", ".env", "id_rsa", "id_ed25519",
     ".pem", ".key", ".p12", ".pfx", "secret", "credential",
 )
 

--- a/scripts/check-severity-dialect.py
+++ b/scripts/check-severity-dialect.py
@@ -129,7 +129,7 @@ def main():
         if rel == ALLOWED_FILE:
             window = allowed_range(lines)
             if window is None:
-                errors.append("%s: Abschnitt '%s' fehlt — ohne ihn hat das "
+                errors.append("%s: Abschnitt '%s' fehlt, damit hat das "
                               "Legacy-Mapping keinen definierten Ort"
                               % (rel, ALLOWED_HEADING))
 

--- a/scripts/check-severity-dialect.py
+++ b/scripts/check-severity-dialect.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Haelt das Schweregrad-Vokabular auf einem Dialekt.
+
+SpecForge hatte zwei Skalen nebeneinander: die F-Stufen F0 bis F5 aus
+references/enforcement/enforcement-engine.md und die aelteren Werte BLOCKER,
+MAJOR und MINOR in der Modulprosa. Beide beschreiben denselben Befund, das
+Mapping zwischen ihnen ist aber verlustbehaftet: F0, F2 und F5 sind ueber den
+Legacy-Weg nicht erreichbar. Wer die alten Werte in einer neuen Regel
+verwendet, erzeugt damit ein Gate, das strenger blockiert als das Regelwerk
+verlangt.
+
+Das Skript prueft zwei Dinge:
+
+1. BLOCKER, MAJOR und MINOR kommen nur noch an einer einzigen Stelle vor:
+   im Abschnitt "Abwaertskompatibilitaet (Legacy-Mapping)" der
+   enforcement-engine.md. Dort sind sie der Eingangs-Uebersetzer fuer alte
+   specforge.json-Dateien ohne severity_model und nichts sonst. Die
+   Versionsnotation MAJOR.MINOR.PATCH ist keine Schweregrad-Angabe und wird
+   vorher aus dem Text genommen.
+2. Jede F-Stufen-Angabe im Payload liegt zwischen F0 und F5. Ein F6 waere
+   ein Tippfehler, den sonst niemand bemerkt, weil er wie eine gueltige
+   Stufe aussieht.
+
+Geprueft werden alle Markdown- und HTML-Dateien des Repos ausser den
+Verzeichnissen .git und dist. Ausgenommen ist docs/f-stufen-entscheidung.md:
+die Entscheidungsdokumentation der Umstellung muss die alten Werte nennen
+duerfen, sonst laesst sich nicht nachlesen, welcher Pruefpunkt vorher welchen
+Wert hatte.
+
+Die zweite Pruefung laeuft nur ueber den Payload, also SKILL.md und
+references/. In README und Landingpage ist ein F gefolgt von einer Ziffer
+nicht zwingend eine F-Stufe.
+
+Exit 0 wenn alles stimmt, sonst 1. Nur Standardbibliothek.
+"""
+
+import os
+import re
+import sys
+
+LEGACY_RE = re.compile(r"\b(BLOCKER|MAJOR|MINOR)\b")
+# MAJOR.MINOR und v{MAJOR}.{MINOR}.{PATCH} sind Versionsangaben, keine
+# Schweregrade. Sie werden vor der Suche entfernt, nicht als Treffer gewertet.
+SEMVER_RE = re.compile(r"\{?MAJOR\}?\.\{?MINOR\}?(?:\.\{?PATCH\}?)?")
+F_LEVEL_RE = re.compile(r"\bF\s?(\d+)\b")
+
+SKIP_DIRS = (".git", "dist", "node_modules", "__pycache__")
+SUFFIXES = (".md", ".html")
+
+# Der einzige Ort im Payload, an dem die Legacy-Werte stehen duerfen.
+ALLOWED_FILE = "references/enforcement/enforcement-engine.md"
+ALLOWED_HEADING = "### Abwärtskompatibilität (Legacy-Mapping)"
+
+# Die Entscheidungsdokumentation der Umstellung. Sie haelt fest, welcher
+# Pruefpunkt vorher welchen Wert hatte, und muss die alten Werte deshalb
+# nennen koennen. Sie liegt ausserhalb des Payloads und wird nicht
+# ausgeliefert. Diese Liste ist bewusst kurz zu halten: jede weitere Datei
+# darin ist eine Stelle, an der der zweite Dialekt zurueckkehren kann.
+ALLOWED_FILES = ("docs/f-stufen-entscheidung.md",)
+
+
+def repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def source_files(root):
+    files = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames
+                             if d not in SKIP_DIRS and not d.startswith("."))
+        for name in sorted(filenames):
+            if not name.endswith(SUFFIXES):
+                continue
+            path = os.path.join(dirpath, name)
+            files.append(os.path.relpath(path, root).replace(os.sep, "/"))
+    return sorted(files)
+
+
+def read_lines(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read().split("\n")
+
+
+def allowed_range(lines):
+    """Zeilennummern des Legacy-Mapping-Abschnitts, 1-basiert.
+
+    Der Abschnitt beginnt bei seiner Ueberschrift und endet vor der naechsten
+    Ueberschrift gleicher oder hoeherer Ebene. Verankert wird an der
+    Ueberschrift, nicht an Zeilennummern, damit der Bereich mitwandert.
+    """
+    start = None
+    for number, line in enumerate(lines, 1):
+        if line.strip() == ALLOWED_HEADING:
+            start = number
+            continue
+        if start is None:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            level = len(stripped) - len(stripped.lstrip("#"))
+            if level <= 3:
+                return start, number - 1
+    if start is None:
+        return None
+    return start, len(lines)
+
+
+def is_payload(rel):
+    return rel == "SKILL.md" or rel.startswith("references/")
+
+
+def main():
+    root = repo_root()
+    errors = []
+    checked = 0
+    legacy_allowed = 0
+
+    for rel in source_files(root):
+        lines = read_lines(os.path.join(root, rel))
+        checked += 1
+
+        if rel in ALLOWED_FILES:
+            print("Uebersprungen:           %s (Entscheidungsdokumentation)"
+                  % rel)
+            continue
+
+        window = None
+        if rel == ALLOWED_FILE:
+            window = allowed_range(lines)
+            if window is None:
+                errors.append("%s: Abschnitt '%s' fehlt — ohne ihn hat das "
+                              "Legacy-Mapping keinen definierten Ort"
+                              % (rel, ALLOWED_HEADING))
+
+        for number, line in enumerate(lines, 1):
+            text = SEMVER_RE.sub("", line)
+            for match in LEGACY_RE.finditer(text):
+                if window is not None and window[0] <= number <= window[1]:
+                    legacy_allowed += 1
+                    continue
+                errors.append("%s:%d: %s statt F-Stufe: %s"
+                              % (rel, number, match.group(1),
+                                 line.strip()[:70]))
+
+            if not is_payload(rel):
+                continue
+            for level in F_LEVEL_RE.findall(line):
+                if int(level) > 5:
+                    errors.append("%s:%d: F%s gibt es nicht, gueltig ist F0 "
+                                  "bis F5: %s"
+                                  % (rel, number, level, line.strip()[:70]))
+
+    print("Geprueft:                %d Markdown- und HTML-Dateien" % checked)
+    print("Legacy-Mapping:          %s, %d zulaessige Vorkommen"
+          % (ALLOWED_FILE, legacy_allowed))
+
+    if errors:
+        print("")
+        print("FEHLER (%d):" % len(errors))
+        for message in errors:
+            print("  - %s" % message)
+        return 1
+
+    print("")
+    print("OK: F-Stufen sind der einzige Schweregrad-Dialekt.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-severity-dialect.py
+++ b/scripts/check-severity-dialect.py
@@ -10,15 +10,22 @@ Legacy-Weg nicht erreichbar. Wer die alten Werte in einer neuen Regel
 verwendet, erzeugt damit ein Gate, das strenger blockiert als das Regelwerk
 verlangt.
 
-Das Skript prueft zwei Dinge:
+Das Skript prueft drei Dinge:
 
 1. BLOCKER, MAJOR und MINOR kommen nur noch an einer einzigen Stelle vor:
    im Abschnitt "Abwaertskompatibilitaet (Legacy-Mapping)" der
    enforcement-engine.md. Dort sind sie der Eingangs-Uebersetzer fuer alte
    specforge.json-Dateien ohne severity_model und nichts sonst. Die
    Versionsnotation MAJOR.MINOR.PATCH ist keine Schweregrad-Angabe und wird
-   vorher aus dem Text genommen.
-2. Jede F-Stufen-Angabe im Payload liegt zwischen F0 und F5. Ein F6 waere
+   vorher aus dem Text genommen. Gesucht wird ohne Ruecksicht auf Gross- und
+   Kleinschreibung, denn "Ein Blocker im Gate" ist die naheliegende deutsche
+   Schreibweise und war bis dahin unsichtbar. Ausgenommen sind die
+   Meldekategorien "Major Incident" und "Klassifikation als Major" aus DORA
+   Art. 19: dort ist Major ein Vorfalltyp und keine Schwere.
+2. Die Kurzform der alten Skala, die Spalte "(B/M/m)", kommt nirgends mehr
+   vor. Sie ist derselbe zweite Dialekt in drei Buchstaben und wurde von der
+   Suche nach den ausgeschriebenen Werten nie gesehen.
+3. Jede F-Stufen-Angabe im Payload liegt zwischen F0 und F5. Ein F6 waere
    ein Tippfehler, den sonst niemand bemerkt, weil er wie eine gueltige
    Stufe aussieht.
 
@@ -28,7 +35,7 @@ die Entscheidungsdokumentation der Umstellung muss die alten Werte nennen
 duerfen, sonst laesst sich nicht nachlesen, welcher Pruefpunkt vorher welchen
 Wert hatte.
 
-Die zweite Pruefung laeuft nur ueber den Payload, also SKILL.md und
+Die dritte Pruefung laeuft nur ueber den Payload, also SKILL.md und
 references/. In README und Landingpage ist ein F gefolgt von einer Ziffer
 nicht zwingend eine F-Stufe.
 
@@ -39,10 +46,23 @@ import os
 import re
 import sys
 
-LEGACY_RE = re.compile(r"\b(BLOCKER|MAJOR|MINOR)\b")
+# Ohne IGNORECASE blieb "Ein Blocker im Gate" unsichtbar, also gerade die
+# Schreibweise, die im deutschen Fliesstext naheliegt. Die Endungen decken
+# die Beugung ab ("Blockern", "Blockers").
+LEGACY_RE = re.compile(r"\b(BLOCKER|MAJOR|MINOR)(?:N|S)?\b", re.I)
+# Die Kurzform derselben Skala. Sie stand als Spaltenkopf "Befunde (B/M/m)"
+# im ausgelieferten Report-Template, neben einer Gesamtbewertung mit vier
+# F-Stufen, und wurde von der Suche oben nie erfasst.
+SHORT_SCALE_RE = re.compile(r"\(\s*B\s*/\s*M\s*/\s*m\s*\)")
 # MAJOR.MINOR und v{MAJOR}.{MINOR}.{PATCH} sind Versionsangaben, keine
 # Schweregrade. Sie werden vor der Suche entfernt, nicht als Treffer gewertet.
-SEMVER_RE = re.compile(r"\{?MAJOR\}?\.\{?MINOR\}?(?:\.\{?PATCH\}?)?")
+SEMVER_RE = re.compile(r"\{?MAJOR\}?\.\{?MINOR\}?(?:\.\{?PATCH\}?)?", re.I)
+# Fachbegriffe der Regulierung. DORA Art. 19 fuehrt den "Major Incident" als
+# Meldekategorie; das Wort bezeichnet dort einen Vorfalltyp und nicht die
+# Schwere eines Befunds. Diese Liste ist so kurz wie moeglich zu halten:
+# jeder weitere Eintrag ist eine Stelle, an der der zweite Dialekt
+# zurueckkommen kann.
+FACHBEGRIFF_RE = re.compile(r"Major[- ]Incidents?|als Major\b", re.I)
 F_LEVEL_RE = re.compile(r"\bF\s?(\d+)\b")
 
 SKIP_DIRS = (".git", "dist", "node_modules", "__pycache__")
@@ -134,7 +154,11 @@ def main():
                               % (rel, ALLOWED_HEADING))
 
         for number, line in enumerate(lines, 1):
-            text = SEMVER_RE.sub("", line)
+            text = FACHBEGRIFF_RE.sub("", SEMVER_RE.sub("", line))
+            if SHORT_SCALE_RE.search(line):
+                errors.append("%s:%d: Kurzform (B/M/m) der alten Skala "
+                              "statt F-Stufen: %s"
+                              % (rel, number, line.strip()[:70]))
             for match in LEGACY_RE.finditer(text):
                 if window is not None and window[0] <= number <= window[1]:
                     legacy_allowed += 1

--- a/scripts/check-severity-dialect.py
+++ b/scripts/check-severity-dialect.py
@@ -19,9 +19,12 @@ Das Skript prueft drei Dinge:
    Versionsnotation MAJOR.MINOR.PATCH ist keine Schweregrad-Angabe und wird
    vorher aus dem Text genommen. Gesucht wird ohne Ruecksicht auf Gross- und
    Kleinschreibung, denn "Ein Blocker im Gate" ist die naheliegende deutsche
-   Schreibweise und war bis dahin unsichtbar. Ausgenommen sind die
-   Meldekategorien "Major Incident" und "Klassifikation als Major" aus DORA
-   Art. 19: dort ist Major ein Vorfalltyp und keine Schwere.
+   Schreibweise und war bis dahin unsichtbar. Ausgenommen sind zwei
+   woertliche Begriffe aus DORA Art. 19, gross geschrieben und sonst nichts:
+   "Major Incident" samt Bindestrich- und Pluralform und "Klassifikation als
+   Major". Dort ist Major ein Vorfalltyp und keine Schwere. Die deutsche
+   Einstufungsformel "gilt als Major" faellt nicht darunter und wird
+   gemeldet.
 2. Die Kurzform der alten Skala, die Spalte "(B/M/m)", kommt nirgends mehr
    vor. Sie ist derselbe zweite Dialekt in drei Buchstaben und wurde von der
    Suche nach den ausgeschriebenen Werten nie gesehen.
@@ -59,10 +62,14 @@ SHORT_SCALE_RE = re.compile(r"\(\s*B\s*/\s*M\s*/\s*m\s*\)")
 SEMVER_RE = re.compile(r"\{?MAJOR\}?\.\{?MINOR\}?(?:\.\{?PATCH\}?)?", re.I)
 # Fachbegriffe der Regulierung. DORA Art. 19 fuehrt den "Major Incident" als
 # Meldekategorie; das Wort bezeichnet dort einen Vorfalltyp und nicht die
-# Schwere eines Befunds. Diese Liste ist so kurz wie moeglich zu halten:
-# jeder weitere Eintrag ist eine Stelle, an der der zweite Dialekt
+# Schwere eines Befunds. Ausgenommen sind nur die beiden woertlichen
+# Begriffe, und bewusst ohne IGNORECASE: ein weiter gefasstes "als Major"
+# haette genau die deutsche Einstufungsformel freigegeben ("gilt als Major",
+# "wird als major eingestuft"), also den Satzbau, in dem der zweite Dialekt
+# im Fliesstext ueberhaupt auftritt. Diese Liste ist so kurz wie moeglich zu
+# halten: jeder weitere Eintrag ist eine Stelle, an der der zweite Dialekt
 # zurueckkommen kann.
-FACHBEGRIFF_RE = re.compile(r"Major[- ]Incidents?|als Major\b", re.I)
+FACHBEGRIFF_RE = re.compile(r"Major[- ]Incidents?|Klassifikation als Major")
 F_LEVEL_RE = re.compile(r"\bF\s?(\d+)\b")
 
 SKIP_DIRS = (".git", "dist", "node_modules", "__pycache__")

--- a/scripts/check-version.py
+++ b/scripts/check-version.py
@@ -27,7 +27,10 @@ Geprueft wird:
    hiesse anders, und der Download bliebe 404.
 6. Die Workflows bauen und pruefen genau diesen Dateinamen, und der
    Release-Workflow haengt an Tags v*.
-7. Mit --tag: der uebergebene Tag ist der aus der Versionsquelle. Der
+7. docs/ci-example.yml pinnt die Composite Action auf denselben Tag. Ein
+   veralteter Pin dort schickt fremde Pipelines auf eine Referenz, die es
+   nicht gibt, und faellt in diesem Repo sonst nie auf.
+8. Mit --tag: der uebergebene Tag ist der aus der Versionsquelle. Der
    Release-Workflow ruft das so auf, damit ein vertipptes Tag kein Release
    erzeugt.
 
@@ -71,6 +74,10 @@ WORKFLOWS = (
     os.path.join(".github", "workflows", "ci.yml"),
     os.path.join(".github", "workflows", "release.yml"),
 )
+
+# Beispiel fuer fremde Repositories. Der Tag darin pinnt die Composite
+# Action und muss mitwandern.
+EXAMPLE_WORKFLOW = os.path.join("docs", "ci-example.yml")
 
 
 def read(path):
@@ -152,9 +159,14 @@ def main(argv):
     readme = read(os.path.join(root, "README.md"))
     html = read(os.path.join(root, "index.html"))
 
+    tag_sources = [("README.md", readme), ("index.html", html)]
+    example = os.path.join(root, EXAMPLE_WORKFLOW)
+    if os.path.isfile(example):
+        tag_sources.append((EXAMPLE_WORKFLOW, read(example)))
+
     checked += check_all("README.md", readme, CURRENT_RE, skill,
                          "die Skill-Version", errors)
-    for label, text in (("README.md", readme), ("index.html", html)):
+    for label, text in tag_sources:
         for hit in FULL_TAG_RE.findall(text):
             checked += 1
             if hit != tag:
@@ -203,7 +215,7 @@ def main(argv):
     if tag_argument is not None:
         print("Uebergebener Tag:        %s" % tag_argument)
     print("Gepruefte Angaben:       %d in CHANGELOG.md, README.md, "
-          "index.html und den Workflows" % checked)
+          "index.html, den Workflows und %s" % (checked, EXAMPLE_WORKFLOW))
 
     if errors:
         print("")

--- a/scripts/check-version.py
+++ b/scripts/check-version.py
@@ -27,10 +27,17 @@ Geprueft wird:
    hiesse anders, und der Download bliebe 404.
 6. Die Workflows bauen und pruefen genau diesen Dateinamen, und der
    Release-Workflow haengt an Tags v*.
-7. docs/ci-example.yml pinnt die Composite Action auf denselben Tag. Ein
-   veralteter Pin dort schickt fremde Pipelines auf eine Referenz, die es
-   nicht gibt, und faellt in diesem Repo sonst nie auf.
-8. Mit --tag: der uebergebene Tag ist der aus der Versionsquelle. Der
+7. docs/ci-example.yml existiert, enthaelt mindestens eine uses-Zeile auf
+   die Composite Action, und jede davon lautet
+   <repo>/.github/actions/specforge-check@<Tag der Versionsquelle>. Geprueft
+   wird also der Pin selbst, nicht nur ein zufaellig vorhandener Tag: '@main'
+   ist ein Fehler, eine geloeschte uses-Zeile ebenso, eine geloeschte Datei
+   ebenso. Der Kommentar in derselben Datei nennt den ungepinnten Stand von
+   main als das Risiko, gegen das die Pruefung schuetzt.
+8. Die Zahl der geprueften Angaben liegt nicht unter MINDESTENS_GEPRUEFT.
+   Ein Zaehler, der still faellt, weil eine Angabe verschwunden ist, meldet
+   nichts; eine Untergrenze meldet es.
+9. Mit --tag: der uebergebene Tag ist der aus der Versionsquelle. Der
    Release-Workflow ruft das so auf, damit ein vertipptes Tag kein Release
    erzeugt.
 
@@ -78,6 +85,23 @@ WORKFLOWS = (
 # Beispiel fuer fremde Repositories. Der Tag darin pinnt die Composite
 # Action und muss mitwandern.
 EXAMPLE_WORKFLOW = os.path.join("docs", "ci-example.yml")
+
+# Die Referenz, mit der ein fremdes Repository die Action einbindet. Der
+# Pfad ist fest, nur der Tag dahinter wandert.
+ACTION_PATH = "GodModeAI2025/specforge-ai-skill/.github/actions/specforge-check"
+ACTION_USES_RE = re.compile(
+    r"uses:\s*" + re.escape(ACTION_PATH) + r"@(\S+)")
+
+# Dateien, die die Action einbinden duerfen. Die erste ist Pflicht, in den
+# uebrigen wird jede vorhandene Referenz mitgeprueft.
+ACTION_SOURCES = (EXAMPLE_WORKFLOW, "README.md", "index.html", "SKILL.md")
+
+# Untergrenze fuer die Zahl der geprueften Angaben. Sie stammt aus einem
+# Lauf auf gruenem Stand und faengt den Fall, dass eine Angabe still
+# verschwindet: der Zaehler faellt dann unter die Grenze, statt sich
+# unbemerkt zu verkleinern. Wer eine Angabe absichtlich entfernt, zieht die
+# Zahl hier nach und begruendet das im Commit.
+MINDESTENS_GEPRUEFT = 19
 
 
 def read(path):
@@ -163,6 +187,29 @@ def main(argv):
     example = os.path.join(root, EXAMPLE_WORKFLOW)
     if os.path.isfile(example):
         tag_sources.append((EXAMPLE_WORKFLOW, read(example)))
+    else:
+        errors.append(
+            "%s fehlt. Ueber diese Datei binden fremde Repositorien die "
+            "Action ein; ohne sie prueft niemand den Pin." % EXAMPLE_WORKFLOW)
+
+    # Der Pin selbst, nicht nur ein irgendwo stehender Tag.
+    pinned = 0
+    for relative in ACTION_SOURCES:
+        path = os.path.join(root, relative)
+        if not os.path.isfile(path):
+            continue
+        for reference in ACTION_USES_RE.findall(read(path)):
+            pinned += 1
+            checked += 1
+            if reference != tag:
+                errors.append(
+                    "%s: Action gepinnt auf '%s@%s', die Versionsquelle sagt "
+                    "'%s'" % (relative, ACTION_PATH, reference, tag))
+    if pinned == 0:
+        errors.append(
+            "%s: keine Zeile 'uses: %s@<Tag>'. Ohne Pin laeuft die Pruefung "
+            "in fremden Pipelines gegen den jeweiligen Stand von main."
+            % (EXAMPLE_WORKFLOW, ACTION_PATH))
 
     checked += check_all("README.md", readme, CURRENT_RE, skill,
                          "die Skill-Version", errors)
@@ -200,6 +247,12 @@ def main(argv):
         errors.append("%s: fehlende Berechtigung contents: write"
                       % WORKFLOWS[1])
 
+    if checked < MINDESTENS_GEPRUEFT:
+        errors.append(
+            "Nur %d Angaben geprueft, erwartet mindestens %d. Eine Angabe "
+            "ist verschwunden, oder die Untergrenze ist nicht nachgezogen."
+            % (checked, MINDESTENS_GEPRUEFT))
+
     if tag_argument is not None:
         checked += 1
         if tag_argument != tag:
@@ -214,8 +267,11 @@ def main(argv):
           % (len(history), history[-1] if history else "-"))
     if tag_argument is not None:
         print("Uebergebener Tag:        %s" % tag_argument)
+    print("Action-Pin:              %d Referenz(en) auf %s@%s"
+          % (pinned, ACTION_PATH, tag))
     print("Gepruefte Angaben:       %d in CHANGELOG.md, README.md, "
-          "index.html, den Workflows und %s" % (checked, EXAMPLE_WORKFLOW))
+          "index.html, den Workflows und %s (mindestens %d)"
+          % (checked, EXAMPLE_WORKFLOW, MINDESTENS_GEPRUEFT))
 
     if errors:
         print("")

--- a/tests/fixtures/01-valide/spec.md
+++ b/tests/fixtures/01-valide/spec.md
@@ -1,0 +1,52 @@
+# Feature-Spezifikation: Zweiter Faktor am Leitsystem-Gateway
+
+**ID:** SF-AUTH
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** kritis
+
+## 5. User Stories & Requirements
+
+### [SF-SEC-001] Anmeldung mit zweitem Faktor
+
+**Typ**: User Story
+**Priorität**: MoSCoW: Must
+
+#### EARS-Requirement
+**Pattern:** Event-Driven
+Wenn ein Betriebsführer sich am Leitsystem-Gateway anmeldet, dann fordert der
+Auth-Service einen TOTP-Code nach RFC 6238 an.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Anmeldung mit gültigem TOTP-Code
+  Given ein Konto mit hinterlegtem TOTP-Geheimnis
+  When der Betriebsführer einen zum Zeitfenster passenden Code eingibt
+  Then gewährt der Auth-Service Zugriff auf das Leitsystem-Gateway
+
+Scenario: Anmeldung mit abgelaufenem TOTP-Code
+  Given ein Konto mit hinterlegtem TOTP-Geheimnis
+  When der Betriebsführer einen Code aus einem vergangenen Zeitfenster eingibt
+  Then verweigert der Auth-Service den Zugriff und schreibt einen Audit-Eintrag
+
+### [SF-AVA-001] Wiederanlauf nach Ausfall des Auth-Service
+
+**Typ**: Technical Story
+**Priorität**: MoSCoW: Must
+
+#### EARS-Requirement
+**Pattern:** State-Driven
+Solange der Auth-Service nicht erreichbar ist, hält das Leitsystem-Gateway
+bestehende Sitzungen für höchstens 15 Minuten aufrecht.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Bestehende Sitzung überdauert einen Ausfall von 10 Minuten
+  Given eine aktive Sitzung am Leitsystem-Gateway
+  When der Auth-Service für 10 Minuten nicht antwortet
+  Then bleibt die Sitzung gültig
+
+Scenario: Sitzung endet nach 15 Minuten ohne Auth-Service
+  Given eine aktive Sitzung am Leitsystem-Gateway
+  When der Auth-Service für 16 Minuten nicht antwortet
+  Then beendet das Leitsystem-Gateway die Sitzung und verlangt eine Neuanmeldung

--- a/tests/fixtures/01-valide/specforge.json
+++ b/tests/fixtures/01-valide/specforge.json
@@ -1,0 +1,18 @@
+{
+  "profile": "kritis",
+  "perspective": "regulated_entity",
+  "severity_model": {
+    "F4": "FAIL",
+    "F3": "CONDITIONAL",
+    "F2": "WARNING",
+    "F1": "INFO",
+    "F0": "PASS",
+    "F5": "SKIP"
+  },
+  "checks_config": {
+    "G1": {
+      "ears_coverage": { "severity": "F4" },
+      "gherkin_minimum": { "severity": "F4" }
+    }
+  }
+}

--- a/tests/fixtures/01-valide/tasks.md
+++ b/tests/fixtures/01-valide/tasks.md
@@ -1,0 +1,5 @@
+# Tasks: Zweiter Faktor am Leitsystem-Gateway
+
+- [ ] T-001 TOTP-Prüfung im Auth-Service ergänzen (SF-SEC-001)
+- [ ] T-002 Audit-Eintrag bei verweigertem Zugriff schreiben (SF-SEC-001)
+- [ ] T-003 Sitzungs-Timeout im Gateway auf 15 Minuten setzen (SF-AVA-001)

--- a/tests/fixtures/02-gherkin-fehlt/spec.md
+++ b/tests/fixtures/02-gherkin-fehlt/spec.md
@@ -1,0 +1,25 @@
+# Feature-Spezifikation: Störungsmeldung an die Leitstelle
+
+**ID:** SF-OPS
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** standard
+
+## 5. User Stories & Requirements
+
+### [SF-OPS-001] Störungsmeldung absetzen
+
+**Typ**: User Story
+**Priorität**: MoSCoW: Must
+
+#### EARS-Requirement
+**Pattern:** Event-Driven
+Wenn ein Betriebsführer eine Störung erfasst, dann übermittelt das
+Meldeportal den Vorgang innerhalb von 60 Sekunden an die Leitstelle.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Störungsmeldung erreicht die Leitstelle
+  Given ein angemeldeter Betriebsführer
+  When er eine Störung mit Anlagenkennung erfasst
+  Then liegt der Vorgang binnen 60 Sekunden in der Leitstelle vor

--- a/tests/fixtures/03-vage-begriffe/spec.md
+++ b/tests/fixtures/03-vage-begriffe/spec.md
@@ -1,0 +1,34 @@
+# Feature-Spezifikation: Auswertung der Messreihen
+
+**ID:** SF-PER
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** standard
+
+## 5. User Stories & Requirements
+
+### [SF-PER-001] Messreihen auswerten
+
+**Typ**: User Story
+**Priorität**: MoSCoW: Should
+
+#### EARS-Requirement
+**Pattern:** Ubiquitous
+Das Auswertungsmodul liefert schnelle Ergebnisse für viele Messreihen, bleibt
+dabei zuverlässig und aktualisiert die Kennzahlen zeitnah.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Auswertung einer Messreihe
+  Given eine erfasste Messreihe
+  When der Auswerter die Auswertung startet
+  Then liegt das Ergebnis vor
+
+Scenario: Auswertung ohne Messwerte
+  Given eine leere Messreihe
+  When der Auswerter die Auswertung startet
+  Then meldet das Auswertungsmodul "keine Messwerte" und bricht ab
+
+#### Offene Fragen
+- [Offen: Aufbewahrungsfrist der Messreihen ggf. nach EnWG prüfen]
+- [Annahme: Die Messreihen sind einfach strukturiert]

--- a/tests/fixtures/04-orphan-task/risiko-abgelaufen.md
+++ b/tests/fixtures/04-orphan-task/risiko-abgelaufen.md
@@ -1,8 +1,7 @@
 # Risiko-Akzeptanzen: Rollenverwaltung
 
-Fixture. Die Frist liegt bewusst weit in der Zukunft: eine Testdatei, deren
-Ergebnis sich an einem Stichtag von selbst dreht, prueft ab diesem Tag etwas
-anderes als vorher.
+Fixture fuer die abgelaufene Frist. Der Block ist vollstaendig, seine Frist
+liegt in der Vergangenheit. Eine Freigabe auf Zeit endet mit der Zeit.
 
 ## Risiko-Akzeptanz: orphan_task T-002
 
@@ -12,5 +11,5 @@ anderes als vorher.
 **Risiko:** Die Protokollansicht ist nicht auf eine Anforderung zurückführbar.
 **Akzeptiert durch:** Leitung Betrieb
 **Kompensation:** Story wird mit der nächsten Spec-Version nachgezogen.
-**Frist:** 2099-12-31
-**Datum:** 2026-09-04
+**Frist:** 2020-01-01
+**Datum:** 2019-12-02

--- a/tests/fixtures/04-orphan-task/risiko-abgelehnt.md
+++ b/tests/fixtures/04-orphan-task/risiko-abgelehnt.md
@@ -1,0 +1,10 @@
+# Risiko-Akzeptanzen: Rollenverwaltung
+
+Fixture fuer den Gegenfall. Die Datei nennt Pruefpunkt und Betreff, verweigert
+die Akzeptanz aber ausdruecklich. Sie darf das Gate nicht aufheben.
+
+## Risiko-Akzeptanz: ABGELEHNT
+
+Der Befund orphan_task zu T-002 wird ausdruecklich NICHT akzeptiert. Die
+Leitung Betrieb hat die Akzeptanz verweigert; die Story ist nachzuziehen,
+bevor implementiert wird.

--- a/tests/fixtures/04-orphan-task/risiko-akzeptanz.md
+++ b/tests/fixtures/04-orphan-task/risiko-akzeptanz.md
@@ -1,0 +1,12 @@
+# Risiko-Akzeptanzen: Rollenverwaltung
+
+## Risiko-Akzeptanz: orphan_task T-002
+
+**Gate:** G4 — Analyze → Implement
+**Prüfpunkt:** orphan_task — T-002 ohne Story-Referenz
+**F-Stufe:** F3 (gewichtiger Mangel)
+**Risiko:** Die Protokollansicht ist nicht auf eine Anforderung zurückführbar.
+**Akzeptiert durch:** Leitung Betrieb
+**Kompensation:** Story wird mit der nächsten Spec-Version nachgezogen.
+**Frist:** 2026-10-01
+**Datum:** 2026-09-04

--- a/tests/fixtures/04-orphan-task/risiko-unvollstaendig.md
+++ b/tests/fixtures/04-orphan-task/risiko-unvollstaendig.md
@@ -1,0 +1,11 @@
+# Risiko-Akzeptanzen: Rollenverwaltung
+
+Fixture fuer den unvollstaendigen Block. Ueberschrift und Pruefpunkt stimmen,
+die Felder des Protokolls fehlen zur Haelfte.
+
+## Risiko-Akzeptanz: orphan_task T-002
+
+**Gate:** G4 — Analyze → Implement
+**Prüfpunkt:** orphan_task — T-002 ohne Story-Referenz
+**F-Stufe:** F3 (gewichtiger Mangel)
+**Risiko:** Die Protokollansicht ist nicht auf eine Anforderung zurückführbar.

--- a/tests/fixtures/04-orphan-task/spec.md
+++ b/tests/fixtures/04-orphan-task/spec.md
@@ -1,0 +1,30 @@
+# Feature-Spezifikation: Rollenverwaltung
+
+**ID:** SF-FUNC
+**Version:** 2026.09.04.1
+**Status:** Draft
+**Profil:** standard
+
+## 5. User Stories & Requirements
+
+### [SF-FUNC-001] Rolle einem Konto zuweisen
+
+**Typ**: User Story
+**Priorität**: MoSCoW: Must
+
+#### EARS-Requirement
+**Pattern:** Event-Driven
+Wenn ein Administrator eine Rolle zuweist, dann protokolliert die
+Rollenverwaltung Zeitpunkt, Konto und Rolle.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Rolle wird zugewiesen
+  Given ein bestehendes Konto ohne Rolle
+  When der Administrator die Rolle "Betriebsführer" zuweist
+  Then trägt das Konto die Rolle und die Zuweisung steht im Protokoll
+
+Scenario: Zuweisung einer unbekannten Rolle
+  Given ein bestehendes Konto ohne Rolle
+  When der Administrator eine nicht vergebene Rollenbezeichnung übermittelt
+  Then weist die Rollenverwaltung die Zuweisung zurück

--- a/tests/fixtures/04-orphan-task/tasks.md
+++ b/tests/fixtures/04-orphan-task/tasks.md
@@ -1,0 +1,4 @@
+# Tasks: Rollenverwaltung
+
+- [ ] T-001 Rollenzuweisung im Backend umsetzen (SF-FUNC-001)
+- [ ] T-002 Protokollansicht im Frontend bauen

--- a/tests/fixtures/06-formatfremd/spec.md
+++ b/tests/fixtures/06-formatfremd/spec.md
@@ -1,0 +1,20 @@
+# Feature-Spezifikation: Rollenverwaltung
+
+**ID:** SF-ROLLEN
+**Version:** 2026.09.04.1
+**Status:** Draft
+
+## 5. User Stories & Requirements
+
+### SF-SEC-001 Anmeldung mit zweitem Faktor
+
+Der Story-Kopf steht hier ohne eckige Klammern und wird deshalb nicht als
+Story erkannt. Die Datei sieht vollstaendig aus, hat fuer den Checker aber
+keinen pruefbaren Inhalt.
+
+**Pattern:** Event-Driven
+
+Scenario: Anmeldung mit gueltigem zweitem Faktor
+  Given ein Konto mit aktivierter Zwei-Faktor-Authentisierung
+  When der Nutzer einen gueltigen TOTP-Code eingibt
+  Then gewaehrt der Auth-Service Zugriff

--- a/tests/fixtures/07-unbekannte-extension/spec.md
+++ b/tests/fixtures/07-unbekannte-extension/spec.md
@@ -1,0 +1,28 @@
+# Feature-Spezifikation: Fixture fuer den Extension-Tippfehler
+
+**ID:** SF-EXT
+**Version:** 2026.09.05.1
+**Status:** Draft
+
+## 5. User Stories & Requirements
+
+### [SF-COM-001] Auslagerungsvertrag im Informationsregister führen
+
+**Typ**: Technical Story
+
+#### EARS-Requirement
+**Pattern:** Ubiquitous
+Das Vertragsregister führt zu jedem IKT-Dienstleistungsvertrag Anbieter, Leistung, Kritikalität
+und Kündigungsfrist.
+
+#### Acceptance Criteria (Gherkin, min. 2)
+
+Scenario: Neuer Vertrag wird aufgenommen
+  Given ein unterzeichneter IKT-Dienstleistungsvertrag
+  When der Auslagerungsbeauftragte ihn erfasst
+  Then enthält das Register alle Pflichtfelder
+
+Scenario: Vertrag ohne Kritikalitätseinstufung
+  Given ein erfasster Vertrag ohne Kritikalitätseinstufung
+  When der Auslagerungsbeauftragte das Register abschließen will
+  Then verweigert das Register den Abschluss

--- a/tests/fixtures/07-unbekannte-extension/specforge.json
+++ b/tests/fixtures/07-unbekannte-extension/specforge.json
@@ -1,0 +1,10 @@
+{
+  "profile": "kritis",
+  "perspective": "regulated_entity",
+  "severity_model": {
+    "F4": "FAIL", "F3": "CONDITIONAL", "F2": "WARNING",
+    "F1": "INFO", "F0": "PASS", "F5": "SKIP"
+  },
+  "extensions": ["@dorra"],
+  "audit": true
+}

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -11,6 +11,7 @@ und ein Test, der erst ein pip install braucht, laeuft in einer fremden
 Pipeline nicht.
 """
 
+import datetime
 import io
 import json
 import os
@@ -21,6 +22,7 @@ from contextlib import redirect_stdout
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "cli"))
 
+from specforge_check import acceptance  # noqa: E402
 from specforge_check import config as config_mod  # noqa: E402
 from specforge_check import extensions  # noqa: E402
 from specforge_check import rules, severity, spec as spec_mod  # noqa: E402
@@ -229,6 +231,11 @@ class ExitCodeTest(unittest.TestCase):
                            fixture("04-orphan-task", "risiko-akzeptanz.md")])
         self.assertEqual(code, 0)
 
+    def test_fehlende_akzeptanzdatei_ist_exit_3(self):
+        code, _ = run_cli([fixture("04-orphan-task"), "--risiko-akzeptanz",
+                           fixture("04-orphan-task", "gibt-es-nicht.md")])
+        self.assertEqual(code, 3)
+
     def test_fehlender_pfad_exit_3(self):
         code, _ = run_cli([os.path.join(FIXTURES, "gibt-es-nicht")])
         self.assertEqual(code, 3)
@@ -240,6 +247,63 @@ class ExitCodeTest(unittest.TestCase):
         self.assertEqual(data["stories"], ["SF-OPS-001"])
         self.assertEqual(data["findings"][0]["severity"], "F4")
         self.assertEqual(data["findings"][0]["check"], "gherkin_minimum")
+
+
+class RisikoAkzeptanzTest(unittest.TestCase):
+    """Eine Freigabe, die kein Dokument verlangt, ist keine Freigabe."""
+
+    HEUTE = datetime.date(2026, 9, 5)
+
+    def _findings(self):
+        document = spec_mod.parse_spec(fixture("04-orphan-task", "spec.md"))
+        tasks = spec_mod.parse_tasks(fixture("04-orphan-task", "tasks.md"))
+        return rules.run(document, tasks, config_mod.Config())
+
+    def _apply(self, datei):
+        return acceptance.apply(self._findings(),
+                                fixture("04-orphan-task", datei), self.HEUTE)
+
+    def test_vollstaendiger_block_akzeptiert(self):
+        accepted, messages = self._apply("risiko-akzeptanz.md")
+        self.assertEqual([f.check for f in accepted], ["orphan_task"])
+        self.assertEqual(messages, [])
+
+    def test_ablehnung_akzeptiert_nicht(self):
+        """Die Datei nennt Pruefpunkt und Betreff und verweigert trotzdem."""
+        accepted, messages = self._apply("risiko-abgelehnt.md")
+        self.assertEqual(accepted, [])
+        self.assertEqual(len(messages), 1)
+        self.assertIn("keine gueltige Akzeptanz", messages[0])
+
+    def test_fehlende_pflichtfelder_akzeptieren_nicht(self):
+        accepted, messages = self._apply("risiko-unvollstaendig.md")
+        self.assertEqual(accepted, [])
+        self.assertIn("Akzeptiert durch", messages[0])
+        self.assertIn("Kompensation", messages[0])
+
+    def test_abgelaufene_frist_akzeptiert_nicht(self):
+        accepted, messages = self._apply("risiko-abgelaufen.md")
+        self.assertEqual(accepted, [])
+        self.assertIn("abgelaufen", messages[0])
+
+    def test_frist_am_stichtag_gilt_noch(self):
+        blocks = acceptance.parse(fixture("04-orphan-task",
+                                          "risiko-abgelaufen.md"))
+        self.assertEqual(blocks[0].problems(datetime.date(2020, 1, 1)), [])
+        self.assertEqual(blocks[0].problems(datetime.date(2020, 1, 2)), [
+            "Frist 2020-01-01 ist am 2020-01-02 abgelaufen"])
+
+    def test_betreff_wird_als_ganzes_wort_gelesen(self):
+        self.assertTrue(acceptance.names("orphan_task T-002", "T-002"))
+        self.assertFalse(acceptance.names("orphan_task T-0021", "T-002"))
+
+    def test_falsche_f_stufe_im_block_akzeptiert_nicht(self):
+        blocks = acceptance.parse(fixture("04-orphan-task",
+                                          "risiko-akzeptanz.md"))
+        finding = self._findings()[0]
+        self.assertTrue(acceptance.matches(blocks[0], finding))
+        finding.level = "F4"
+        self.assertFalse(acceptance.matches(blocks[0], finding))
 
 
 class ExtensionTest(unittest.TestCase):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -355,10 +355,15 @@ class ExtensionTest(unittest.TestCase):
 
 
 class NfrLueckeTest(unittest.TestCase):
-    """Der Fall, an dem das Legacy-Mapping scheiterte.
+    """Was die Perspektive im Linter bewirkt.
 
-    Dieselbe fehlende Anforderung bekommt je nach Perspektive F4 oder F2.
-    Ueber BLOCKER/MAJOR/MINOR waren beide Werte nicht darstellbar.
+    Die Stufe der Luecke selbst steht im Marker, den der Autor gesetzt hat.
+    Die Perspektive entscheidet, ob diese Einstufung zur F-Stufen-Tabelle
+    der Extension passt: dieselbe Spec ergibt fuer regulated_entity nur den
+    nfr_gap (Fall 03) und fuer advisory zusaetzlich nfr_severity (Fall 06).
+    Fall 04 zeigt die zur Perspektive passende mildere Einstufung, die als
+    F2 das Gate passiert; ueber BLOCKER/MAJOR/MINOR war dieser Wert nicht
+    darstellbar.
     """
 
     def _run(self, name):
@@ -372,6 +377,20 @@ class NfrLueckeTest(unittest.TestCase):
         findings = self._run("03-dora-regulated-ohne-irm01")
         self.assertEqual([(f.check, f.level, f.subject) for f in findings],
                          [("nfr_gap", "F4", "IRM-01")])
+
+    def test_paar_unterscheidet_sich_nur_in_der_perspektive(self):
+        """Ein Beleg mit zwei Variablen belegt nichts."""
+        def read(case):
+            path = os.path.join(ROOT, "evals", "golden", case, "spec.md")
+            with open(path, encoding="utf-8") as handle:
+                return handle.read()
+
+        self.assertEqual(read("03-dora-regulated-ohne-irm01"),
+                         read("06-dora-falsche-f-stufe"))
+
+    def test_nicht_markierte_luecke_bleibt_unbemerkt(self):
+        """Grenze des Linters, festgehalten statt behauptet."""
+        self.assertEqual(self._run("08-dora-luecke-undokumentiert"), [])
 
     def test_advisory_erzeugt_pflicht_task(self):
         findings = self._run("04-dora-advisory-ohne-irm01")

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests fuer specforge check.
+
+Aufruf aus dem Repo-Wurzelverzeichnis:
+
+    python3 -m unittest discover -s tests -v
+
+Nur Standardbibliothek, kein pytest. Die CI dieses Repos installiert nichts,
+und ein Test, der erst ein pip install braucht, laeuft in einer fremden
+Pipeline nicht.
+"""
+
+import io
+import json
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "cli"))
+
+from specforge_check import config as config_mod  # noqa: E402
+from specforge_check import rules, severity, spec as spec_mod  # noqa: E402
+from specforge_check.__main__ import main  # noqa: E402
+
+FIXTURES = os.path.join(ROOT, "tests", "fixtures")
+
+
+def fixture(name, *parts):
+    return os.path.join(FIXTURES, name, *parts)
+
+
+def run_cli(argv):
+    """Ruft den Checker auf und gibt (exit_code, ausgabe) zurueck."""
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        code = main(argv)
+    return code, buffer.getvalue()
+
+
+class ParserTest(unittest.TestCase):
+    def test_stories_und_szenarien_werden_erkannt(self):
+        document = spec_mod.parse_spec(fixture("01-valide", "spec.md"))
+        self.assertEqual([s.id for s in document.stories],
+                         ["SF-SEC-001", "SF-AVA-001"])
+        self.assertEqual([len(s.scenarios) for s in document.stories], [2, 2])
+
+    def test_pattern_feld_wird_gelesen(self):
+        document = spec_mod.parse_spec(fixture("01-valide", "spec.md"))
+        self.assertEqual(document.stories[0].pattern, "Event-Driven")
+        self.assertEqual(document.stories[1].pattern, "State-Driven")
+
+    def test_id_schema(self):
+        self.assertTrue(spec_mod.valid_id("SF-SEC-001"))
+        self.assertFalse(spec_mod.valid_id("SF-XXX-001"))
+        self.assertFalse(spec_mod.valid_id("SF-SEC-1"))
+
+    def test_tasks_referenzen(self):
+        tasks = spec_mod.parse_tasks(fixture("01-valide", "tasks.md"))
+        self.assertEqual(len(tasks), 3)
+        self.assertEqual(tasks[0][2], ["SF-SEC-001"])
+
+
+class SeverityTest(unittest.TestCase):
+    def test_legacy_wird_uebersetzt(self):
+        self.assertEqual(severity.normalise("BLOCKER"), "F4")
+        self.assertEqual(severity.normalise("MAJOR"), "F3")
+        self.assertEqual(severity.normalise("MINOR"), "F1")
+
+    def test_schreibweisen(self):
+        self.assertEqual(severity.normalise("F 4"), "F4")
+        self.assertEqual(severity.normalise(True), "F4")
+        self.assertEqual(severity.normalise(False), "F1")
+        self.assertIsNone(severity.normalise("F9"))
+
+
+class ConfigTest(unittest.TestCase):
+    def test_perspektive_schlaegt_default(self):
+        configuration = config_mod.Config({
+            "perspective": "advisory",
+            "severity_model": {},
+            "checks_config": {"G1": {"stride_complete": {"severity": {
+                "_default": "F3", "regulated_entity": "F4",
+                "advisory": "F1"}}}},
+        })
+        self.assertEqual(
+            configuration.severity_for("stride_complete", "F3"), "F1")
+
+    def test_default_bei_unbekannter_perspektive(self):
+        configuration = config_mod.Config({
+            "perspective": "ict_provider",
+            "severity_model": {},
+            "checks_config": {"G1": {"stride_complete": {"severity": {
+                "_default": "F3", "advisory": "F1"}}}},
+        })
+        self.assertEqual(
+            configuration.severity_for("stride_complete", "F4"), "F3")
+
+    def test_ohne_default_gilt_f3(self):
+        configuration = config_mod.Config({
+            "severity_model": {},
+            "checks_config": {"G1": {"stride_complete": {"severity": {
+                "advisory": "F1"}}}},
+        })
+        self.assertEqual(
+            configuration.severity_for("stride_complete", "F4"), "F3")
+
+    def test_altkonfiguration_ohne_severity_model(self):
+        configuration = config_mod.Config({
+            "checks_config": {"G1": {"gherkin_minimum": {"required": True}}},
+        })
+        self.assertTrue(configuration.legacy)
+        self.assertEqual(
+            configuration.severity_for("gherkin_minimum", "F1"), "F4")
+
+    def test_legacy_wert_in_checks_config(self):
+        configuration = config_mod.Config({
+            "checks_config": {"G1": {"vague_terms": {"severity": "MAJOR"}}},
+        })
+        self.assertEqual(configuration.severity_for("vague_terms", "F4"),
+                         "F3")
+
+
+class RuleTest(unittest.TestCase):
+    def _findings(self, name, after_clarify=False, with_tasks=False):
+        document = spec_mod.parse_spec(fixture(name, "spec.md"))
+        tasks = (spec_mod.parse_tasks(fixture(name, "tasks.md"))
+                 if with_tasks else None)
+        configuration = config_mod.load(
+            config_mod.find(fixture(name, "spec.md")))
+        return rules.run(document, tasks, configuration, after_clarify)
+
+    def test_valide_spec_ohne_befund(self):
+        self.assertEqual(self._findings("01-valide", with_tasks=True), [])
+
+    def test_fehlende_gherkin_szenarien_sind_f4(self):
+        findings = self._findings("02-gherkin-fehlt")
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].check, "gherkin_minimum")
+        self.assertEqual(findings[0].level, "F4")
+        self.assertEqual(findings[0].subject, "SF-OPS-001")
+
+    def test_vage_begriffe_sind_f4(self):
+        findings = [f for f in self._findings("03-vage-begriffe")
+                    if f.check == "vague_terms"]
+        self.assertEqual(sorted(f.message for f in findings), [
+            "vager Begriff 'schnell'",
+            "vager Begriff 'viele'",
+            "vager Begriff 'zuverlässig'",
+        ])
+        self.assertEqual(set(f.level for f in findings), {"F4"})
+
+    def test_marker_schuetzen_vor_falschbefund(self):
+        """"einfach" steht nur in einem [Annahme:]-Marker und zaehlt nicht."""
+        findings = self._findings("03-vage-begriffe")
+        self.assertNotIn("vager Begriff 'einfach'",
+                         [f.message for f in findings])
+
+    def test_offene_marker_erst_nach_clarify(self):
+        vorher = [f for f in self._findings("03-vage-begriffe")
+                  if f.check == "open_marker"]
+        nachher = [f for f in self._findings("03-vage-begriffe",
+                                             after_clarify=True)
+                   if f.check == "open_marker"]
+        self.assertEqual(vorher, [])
+        self.assertEqual(len(nachher), 2)
+        self.assertEqual(set(f.level for f in nachher), {"F3"})
+
+    def test_orphan_task_ist_f3(self):
+        findings = [f for f in self._findings("04-orphan-task",
+                                              with_tasks=True)
+                    if f.check == "orphan_task"]
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].subject, "T-002")
+        self.assertEqual(findings[0].level, "F3")
+
+
+class ExitCodeTest(unittest.TestCase):
+    def test_valide_spec_exit_0(self):
+        code, output = run_cli([fixture("01-valide")])
+        self.assertEqual(code, 0)
+        self.assertIn("Ergebnis: PASS", output)
+
+    def test_fehlende_gherkin_szenarien_exit_1(self):
+        code, output = run_cli([fixture("02-gherkin-fehlt")])
+        self.assertEqual(code, 1)
+        self.assertIn("[F4] Gherkin-Szenarien", output)
+        self.assertIn("Ergebnis: FAIL", output)
+
+    def test_orphan_task_exit_2(self):
+        code, output = run_cli([fixture("04-orphan-task")])
+        self.assertEqual(code, 2)
+        self.assertIn("Ergebnis: CONDITIONAL", output)
+
+    def test_risiko_akzeptanz_hebt_exit_2_auf(self):
+        code, _ = run_cli([fixture("04-orphan-task"),
+                           "--risiko-akzeptanz",
+                           fixture("04-orphan-task", "risiko-akzeptanz.md")])
+        self.assertEqual(code, 0)
+
+    def test_fehlender_pfad_exit_3(self):
+        code, _ = run_cli([os.path.join(FIXTURES, "gibt-es-nicht")])
+        self.assertEqual(code, 3)
+
+    def test_json_ausgabe(self):
+        code, output = run_cli([fixture("02-gherkin-fehlt"), "--json"])
+        self.assertEqual(code, 1)
+        data = json.loads(output)
+        self.assertEqual(data["stories"], ["SF-OPS-001"])
+        self.assertEqual(data["findings"][0]["severity"], "F4")
+        self.assertEqual(data["findings"][0]["check"], "gherkin_minimum")
+
+
+class KonfigurationsWirkungTest(unittest.TestCase):
+    def test_checks_config_senkt_die_stufe(self):
+        """Eine Perspektive darf die Default-Stufe ueberschreiben."""
+        configuration = config_mod.Config({
+            "perspective": "advisory",
+            "severity_model": {},
+            "checks_config": {"G1": {"gherkin_minimum": {"severity": {
+                "_default": "F4", "advisory": "F2"}}}},
+        })
+        document = spec_mod.parse_spec(fixture("02-gherkin-fehlt", "spec.md"))
+        findings = rules.run(document, None, configuration)
+        self.assertEqual([f.level for f in findings], ["F2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -22,6 +22,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "cli"))
 
 from specforge_check import config as config_mod  # noqa: E402
+from specforge_check import extensions  # noqa: E402
 from specforge_check import rules, severity, spec as spec_mod  # noqa: E402
 from specforge_check.__main__ import main  # noqa: E402
 
@@ -211,6 +212,85 @@ class ExitCodeTest(unittest.TestCase):
         self.assertEqual(data["stories"], ["SF-OPS-001"])
         self.assertEqual(data["findings"][0]["severity"], "F4")
         self.assertEqual(data["findings"][0]["check"], "gherkin_minimum")
+
+
+class ExtensionTest(unittest.TestCase):
+    def setUp(self):
+        self.packages = extensions.load(ROOT)
+
+    def test_dora_tabelle_wird_gelesen(self):
+        self.assertIn("@dora", self.packages)
+        self.assertIn("IRM", self.packages["@dora"])
+
+    def test_perspektive_bestimmt_die_stufe(self):
+        """Dieselbe Kategorie, drei Perspektiven, drei Stufen."""
+        self.assertEqual(
+            extensions.allowed_levels(self.packages, "IRM",
+                                      "regulated_entity"), {"F4"})
+        self.assertEqual(
+            extensions.allowed_levels(self.packages, "IRM", "advisory"),
+            {"F2"})
+
+    def test_mehrdeutige_zelle_laesst_beide_stufen_zu(self):
+        """'F4 (CTPP) / F3' ist eine Bedingung, kein Tippfehler."""
+        nur_dora = extensions.load(ROOT, ["@dora"])
+        self.assertEqual(
+            extensions.allowed_levels(nur_dora, "IRM", "ict_provider"),
+            {"F3", "F4"})
+
+    def test_kollidierendes_kuerzel_vereinigt_die_stufen(self):
+        """IRM fuehren @dora und @bait mit verschiedener Bedeutung.
+
+        Sind beide aktiv, ist das Kuerzel nicht eindeutig. Der Checker
+        beanstandet dann nur, was keine der beiden Extensions vorsieht.
+        """
+        self.assertIn("IRM", self.packages["@dora"])
+        self.assertIn("IRM", self.packages["@bait"])
+        self.assertEqual(
+            extensions.allowed_levels(self.packages, "IRM", "advisory"),
+            {"F2"})
+        self.assertEqual(
+            extensions.allowed_levels(self.packages, "IRM", "ict_provider"),
+            {"F3", "F4"})
+
+    def test_unbekannte_kategorie_bleibt_ungeprueft(self):
+        self.assertIsNone(
+            extensions.allowed_levels(self.packages, "ZZZ", "advisory"))
+
+    def test_default_spalte_greift_ohne_perspektive(self):
+        self.assertEqual(
+            extensions.allowed_levels(self.packages, "GOV", None), {"F3"})
+
+
+class NfrLueckeTest(unittest.TestCase):
+    """Der Fall, an dem das Legacy-Mapping scheiterte.
+
+    Dieselbe fehlende Anforderung bekommt je nach Perspektive F4 oder F2.
+    Ueber BLOCKER/MAJOR/MINOR waren beide Werte nicht darstellbar.
+    """
+
+    def _run(self, name):
+        path = os.path.join(ROOT, "evals", "golden", name, "spec.md")
+        document = spec_mod.parse_spec(path)
+        configuration = config_mod.load(config_mod.find(path))
+        packages = extensions.load(ROOT)
+        return rules.run(document, None, configuration, False, packages)
+
+    def test_regulated_entity_blockiert(self):
+        findings = self._run("03-dora-regulated-ohne-irm01")
+        self.assertEqual([(f.check, f.level, f.subject) for f in findings],
+                         [("nfr_gap", "F4", "IRM-01")])
+
+    def test_advisory_erzeugt_pflicht_task(self):
+        findings = self._run("04-dora-advisory-ohne-irm01")
+        self.assertEqual([(f.check, f.level, f.subject) for f in findings],
+                         [("nfr_gap", "F2", "IRM-01")])
+
+    def test_zu_harte_einstufung_ist_ein_befund(self):
+        findings = self._run("06-dora-falsche-f-stufe")
+        self.assertEqual([(f.check, f.level) for f in findings],
+                         [("nfr_gap", "F4"), ("nfr_severity", "F3")])
+        self.assertIn("verlangt F2", findings[1].message)
 
 
 class KonfigurationsWirkungTest(unittest.TestCase):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -236,6 +236,12 @@ class ExitCodeTest(unittest.TestCase):
                            fixture("04-orphan-task", "gibt-es-nicht.md")])
         self.assertEqual(code, 3)
 
+    def test_unbekannte_extension_exit_3(self):
+        """Ein Tippfehler im Extension-Namen nahm bisher still die
+        F-Stufen-Pruefung heraus."""
+        code, _ = run_cli([fixture("07-unbekannte-extension")])
+        self.assertEqual(code, 3)
+
     def test_fehlender_pfad_exit_3(self):
         code, _ = run_cli([os.path.join(FIXTURES, "gibt-es-nicht")])
         self.assertEqual(code, 3)
@@ -352,6 +358,27 @@ class ExtensionTest(unittest.TestCase):
     def test_default_spalte_greift_ohne_perspektive(self):
         self.assertEqual(
             extensions.allowed_levels(self.packages, "GOV", None), {"F3"})
+
+    def test_schreibweise_des_namens_ist_egal(self):
+        """'@DORA' hat vorher stillschweigend gar nichts geladen."""
+        for name in ("@dora", "@DORA", "dora", " Dora "):
+            self.assertEqual(sorted(extensions.load(ROOT, [name])), ["@dora"])
+
+    def test_leere_liste_laedt_nichts(self):
+        """[] heisst 'keine Extension', nicht 'nicht gesetzt'."""
+        self.assertEqual(extensions.load(ROOT, []), {})
+        self.assertEqual(sorted(extensions.load(ROOT, None)),
+                         ["@bait", "@dora"])
+
+    def test_unbekannter_name_ist_ein_aufrufproblem(self):
+        with self.assertRaises(extensions.ExtensionFehler) as fehler:
+            extensions.load(ROOT, ["@dorra"])
+        self.assertIn("@dorra", str(fehler.exception))
+        self.assertIn("@dora", str(fehler.exception))
+
+    def test_extensions_muss_eine_liste_sein(self):
+        with self.assertRaises(extensions.ExtensionFehler):
+            extensions.load(ROOT, "@dora")
 
 
 class NfrLueckeTest(unittest.TestCase):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -178,6 +178,34 @@ class RuleTest(unittest.TestCase):
         self.assertEqual(findings[0].level, "F3")
 
 
+class OhneStoryTest(unittest.TestCase):
+    """Eine Spec ohne erkannte Story darf kein bestandener Lauf sein."""
+
+    def test_leere_datei_ist_f4(self):
+        code, output = run_cli([fixture("05-leer")])
+        self.assertEqual(code, 1)
+        self.assertIn("[F4] Keine pruefbare Story", output)
+        self.assertIn("Datei ist leer", output)
+        self.assertNotIn("Alle Pruefpunkte erfuellt", output)
+
+    def test_fremdes_story_format_ist_f4(self):
+        code, output = run_cli([fixture("06-formatfremd")])
+        self.assertEqual(code, 1)
+        self.assertIn("kein Story-Kopf", output)
+        self.assertNotIn("Alle Pruefpunkte erfuellt", output)
+
+    def test_checks_config_kann_die_stufe_nicht_senken(self):
+        """Die Stufe steht im Code, nicht in der Konfiguration."""
+        configuration = config_mod.Config({
+            "severity_model": {},
+            "checks_config": {"G1": {"no_stories": {"severity": "F1"}}},
+        })
+        document = spec_mod.parse_spec(fixture("05-leer", "spec.md"))
+        findings = rules.run(document, None, configuration)
+        self.assertEqual([(f.check, f.level) for f in findings],
+                         [("no_stories", "F4")])
+
+
 class ExitCodeTest(unittest.TestCase):
     def test_valide_spec_exit_0(self):
         code, output = run_cli([fixture("01-valide")])

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -25,6 +25,7 @@ sys.path.insert(0, os.path.join(ROOT, "cli"))
 from specforge_check import acceptance  # noqa: E402
 from specforge_check import config as config_mod  # noqa: E402
 from specforge_check import extensions  # noqa: E402
+from specforge_check import report  # noqa: E402
 from specforge_check import rules, severity, spec as spec_mod  # noqa: E402
 from specforge_check.__main__ import main  # noqa: E402
 
@@ -449,6 +450,64 @@ class KonfigurationsWirkungTest(unittest.TestCase):
         document = spec_mod.parse_spec(fixture("02-gherkin-fehlt", "spec.md"))
         findings = rules.run(document, None, configuration)
         self.assertEqual([f.level for f in findings], ["F2"])
+
+
+class AusgabeTest(unittest.TestCase):
+    """Ein Gate, das nicht lief, muss in der Ausgabe stehen.
+
+    Ohne tasks.md fiel Gate G4 frueher kommentarlos aus dem Bericht. Eine
+    geloeschte oder falsch abgelegte Datei nahm damit die AP-07-Pruefung
+    heraus, und was uebrig blieb, sah aus wie ein sauberer Lauf.
+    """
+
+    def _teile(self, mit_tasks):
+        document = spec_mod.parse_spec(fixture("04-orphan-task", "spec.md"))
+        tasks = (spec_mod.parse_tasks(fixture("04-orphan-task", "tasks.md"))
+                 if mit_tasks else None)
+        findings = rules.run(document, tasks, config_mod.Config())
+        return document, tasks, findings
+
+    def _ergebnisse(self, zeilen):
+        """Gate-Titel -> Ergebnis, aus den gerenderten Zeilen gelesen."""
+        gefunden = {}
+        gate = None
+        for zeile in zeilen:
+            if "Gate G" in zeile:
+                gate = zeile.split("Gate ")[1].split(":")[0]
+            elif "Ergebnis:" in zeile and gate:
+                gefunden[gate] = zeile.split("Ergebnis: ")[1].split(" ")[0]
+        return gefunden
+
+    def test_fehlende_tasks_datei_steht_in_der_ausgabe(self):
+        document, tasks, findings = self._teile(False)
+        zeilen = report.render(document, findings, tasks, [])
+        text = "\n".join(zeilen)
+        self.assertIn("Gate G4", text)
+        self.assertIn("keine tasks.md gefunden", text)
+        self.assertEqual(self._ergebnisse(zeilen)["G4"], "SKIP")
+
+    def test_gate_g1_bleibt_davon_unberuehrt(self):
+        document, tasks, findings = self._teile(False)
+        zeilen = report.render(document, findings, tasks, [])
+        self.assertEqual(self._ergebnisse(zeilen)["G1"], "PASS")
+
+    def test_mit_tasks_datei_wird_wieder_geprueft(self):
+        document, tasks, findings = self._teile(True)
+        zeilen = report.render(document, findings, tasks, [])
+        text = "\n".join(zeilen)
+        self.assertNotIn("keine tasks.md gefunden", text)
+        self.assertEqual(self._ergebnisse(zeilen)["G4"], "CONDITIONAL")
+
+    def test_json_nennt_die_nicht_gelaufenen_pruefpunkte(self):
+        document, tasks, findings = self._teile(False)
+        daten = json.loads(report.as_json(document, findings, [], (), tasks))
+        self.assertEqual(daten["skipped_checks"],
+                         ["orphan_task", "orphan_story"])
+
+    def test_json_ist_leer_wenn_alles_lief(self):
+        document, tasks, findings = self._teile(True)
+        daten = json.loads(report.as_json(document, findings, [], (), tasks))
+        self.assertEqual(daten["skipped_checks"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -407,13 +407,19 @@ class NfrLueckeTest(unittest.TestCase):
 
     def test_paar_unterscheidet_sich_nur_in_der_perspektive(self):
         """Ein Beleg mit zwei Variablen belegt nichts."""
-        def read(case):
-            path = os.path.join(ROOT, "evals", "golden", case, "spec.md")
+        def read(case, name):
+            path = os.path.join(ROOT, "evals", "golden", case, name)
             with open(path, encoding="utf-8") as handle:
                 return handle.read()
 
-        self.assertEqual(read("03-dora-regulated-ohne-irm01"),
-                         read("06-dora-falsche-f-stufe"))
+        self.assertEqual(read("03-dora-regulated-ohne-irm01", "spec.md"),
+                         read("06-dora-falsche-f-stufe", "spec.md"))
+
+        eins = json.loads(read("03-dora-regulated-ohne-irm01",
+                               "specforge.json"))
+        zwei = json.loads(read("06-dora-falsche-f-stufe", "specforge.json"))
+        self.assertNotEqual(eins.pop("perspective"), zwei.pop("perspective"))
+        self.assertEqual(eins, zwei)
 
     def test_nicht_markierte_luecke_bleibt_unbemerkt(self):
         """Grenze des Linters, festgehalten statt behauptet."""

--- a/tests/test_severity_dialect.py
+++ b/tests/test_severity_dialect.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests fuer scripts/check-severity-dialect.py.
+
+Der Waechter haelt das Schweregrad-Vokabular auf den F-Stufen. Seine
+Ausnahmeliste ist der empfindliche Teil: jeder Eintrag darin ist eine Stelle,
+an der der zweite Dialekt zurueckkommen kann, und ein zu weit gefasster
+Eintrag macht den Waechter still, ohne dass die Ausgabe das zeigt. Genau das
+war der Fall, als die Ausnahme "als Major" hiess und mit IGNORECASE lief:
+sie gab die deutsche Einstufungsformel frei, also den Satzbau, in dem der
+alte Wert im Fliesstext ueberhaupt vorkommt.
+
+Aufruf aus dem Repo-Wurzelverzeichnis:
+
+    python3 -m unittest discover -s tests -v
+
+Nur Standardbibliothek.
+"""
+
+import importlib.util
+import io
+import os
+import re
+import unittest
+from contextlib import redirect_stdout
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PFAD = os.path.join(ROOT, "scripts", "check-severity-dialect.py")
+
+_spec = importlib.util.spec_from_file_location("check_severity_dialect", PFAD)
+waechter = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(waechter)
+
+
+def treffer(zeile):
+    """Die Legacy-Treffer einer Zeile, so wie main() sie zaehlt."""
+    text = waechter.FACHBEGRIFF_RE.sub("", waechter.SEMVER_RE.sub("", zeile))
+    return [match.group(1) for match in waechter.LEGACY_RE.finditer(text)]
+
+
+class DialektTest(unittest.TestCase):
+    def test_deutsche_einstufungsformel_wird_gemeldet(self):
+        self.assertEqual(
+            treffer("Ein Befund dieser Art gilt als Major und blockiert."),
+            ["Major"])
+
+    def test_kleingeschriebene_einstufung_wird_gemeldet(self):
+        self.assertEqual(
+            treffer("Ein zweiter Befund wird als major eingestuft."),
+            ["major"])
+
+    def test_deutsche_grossschreibung_wird_gemeldet(self):
+        self.assertEqual(treffer("Loop bis Blocker-frei."), ["Blocker"])
+
+    def test_dora_meldekategorie_bleibt_frei(self):
+        self.assertEqual(
+            treffer("Ist der Meldefluss fuer Major Incidents definiert?"), [])
+        self.assertEqual(
+            treffer("| INC-04 | Major-Incident-Meldung — Initial |"), [])
+
+    def test_dora_klassifikation_bleibt_frei(self):
+        self.assertEqual(
+            treffer("Initialnotifikation ≤4h nach Klassifikation als Major, "
+                    "max. 24h nach Erkennung"), [])
+
+    def test_versionsnotation_ist_kein_schweregrad(self):
+        self.assertEqual(treffer("v{MAJOR}.{MINOR}.{PATCH}"), [])
+        self.assertEqual(treffer("Schema MAJOR.MINOR.PATCH"), [])
+
+    def test_kurzform_der_alten_skala(self):
+        self.assertTrue(waechter.SHORT_SCALE_RE.search("| Befunde (B/M/m) |"))
+        self.assertFalse(waechter.SHORT_SCALE_RE.search("| F4/F3/F2/F1 |"))
+
+    def test_ausnahmeliste_bleibt_kurz(self):
+        """Zwei woertliche DORA-Begriffe, nicht mehr, und ohne IGNORECASE."""
+        self.assertEqual(waechter.FACHBEGRIFF_RE.pattern,
+                         r"Major[- ]Incidents?|Klassifikation als Major")
+        self.assertFalse(waechter.FACHBEGRIFF_RE.flags & re.I)
+
+    def test_repo_haelt_den_dialekt_ein(self):
+        with redirect_stdout(io.StringIO()):
+            code = waechter.main()
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Welle 5: ein Schweregrad-Dialekt, ein Linter, sechs Golden Specs

### Was umgesetzt ist

**F-Stufen sind der einzige Schweregrad-Dialekt.** Der Payload sprach zwei Skalen: F0 bis F5 in der Enforcement Engine, in Modus 10 und in beiden Regulatorik-Extensions, daneben BLOCKER, MAJOR und MINOR in fuenf Fachmodulen, in den Golden Principles und in beiden Templates. Derselbe Mangel bekam je nach antwortendem Modul eine andere Stufe. Von 150 Zeilen mit dem alten Vokabular in SKILL.md und references/ sind fuenf uebrig, alle im Abschnitt "Abwaertskompatibilitaet (Legacy-Mapping)" der enforcement-engine.md.

Das war kein Suchen-und-Ersetzen. Das Mapping ist verlustbehaftet, die drei alten Werte treffen nur F4, F3 und F1, und MAJOR diente im Payload als Sammelstufe: es stand fuer "Gate blockiert bis zur Risiko-Akzeptanz" ebenso wie fuer "das Artefakt gehoert in eine eigene Datei". Pauschal auf F3 uebersetzt haette jedes dieser Formalien-Findings eine Risiko-Akzeptanz durch das Leitungsorgan verlangt. Die angewandte Regel: fuehrt ein Gate oder die Anti-Pattern-Tabelle denselben Pruefpunkt, gilt deren Wert; sonst entscheidet die Einzelbewertung. Vier Pruefpunkte sind dadurch strenger geworden, sechs milder. Die Herleitung samt Tabelle steht in `docs/f-stufen-entscheidung.md`.

Ein Widerspruch musste dabei aufgeloest werden, den die Engine selbst trug: Gate G1 fuehrte das Gherkin-Minimum als F4, AP-06 mit derselben Erkennung als F3. Jetzt gilt: weniger als zwei Szenarien ist der Gate-Pruefpunkt und damit F4, AP-06 greift eine Stufe darueber und bleibt F3.

Der Legacy-Uebersetzer bleibt, mit ausdruecklich eingeschraenktem Zweck: eine alte `specforge.json` ohne `severity_model` einlesen. `scripts/check-severity-dialect.py` haelt das in der CI fest und prueft nebenbei, dass keine F-Stufe ueber F5 auftaucht.

**`specforge check`.** Das Enforcement lief bisher nur in der Claude-Session. `cli/specforge check` liest eine spec.md, optional eine tasks.md daneben, und meldet Befunde im Gate-Ergebnis-Format der Enforcement Engine. Geprueft wird, was ohne Sprachmodell entscheidbar ist: EARS-Pattern (F4), Gherkin-Mindestanzahl (F4), die AP-04-Blocklist (F4), die eindeutigen SOPHIST-Trigger aus AP-08 (F3), offene Marker nach Clarify (F3), ID-Schema (F1) und Duplikate (F4), Traceability zwischen Story und Task (F3), dazu dokumentierte NFR-Luecken und deren Einstufung. Alles, was Bedeutung statt Struktur ist, meldet der Linter nicht als bestanden, sondern gar nicht.

Exit 1 bei F4, 2 bei F3 ohne dokumentierte Risiko-Akzeptanz, 3 beim Aufrufproblem. `checks_config` aus der specforge.json ueberschreibt die Default-Stufen, perspektivenabhaengig nach derselben Aufloesung wie in der Session. Kein pip install, nur Standardbibliothek, Tests mit unittest: das Repo ist ein Markdown-Skill, und ein Linter, der erst eine Installation braucht, wird in einer fremden Pipeline nicht benutzt. Das gelesene Format steht in `docs/spec-format.md`.

**Golden Specs.** Das Repo enthielt keine einzige fertige Spezifikation. `evals/golden/` enthaelt jetzt sechs Faelle mit `expected.json`, `evals/run_static.py` faehrt sie deterministisch durch den Linter. Fall 01 ist eine vollstaendige KRITIS-Spec nach dem Template. Das Paar 03/04 ist der Grund fuer die Suite: dieselbe fehlende DORA-Anforderung ergibt fuer ein Finanzunternehmen F4 und blockiert, fuer ein Beratungsprojekt F2 und erzeugt einen Pflicht-Task vor Go-Live. Fall 06 zeigt die Gegenrichtung, eine zu hart eingestufte Luecke. Dafuer liest der Linter die F-Stufen-Zuordnung aus den Extension-Manifesten, statt sie zu wiederholen.

### Wie geprueft wurde

Alle elf Schritte aus `ci.yml` lokal gefahren, jeder exit 0. Die vier bestehenden Konsistenzskripte sind unveraendert gruen (41, 8 und 58 Pruefpunkte, 18 Zahlenangaben, 18 Versionsangaben). Neu dazu: 33 Unit-Tests, fuenf Fixture-Laeufe ueber die Kommandozeile, sechs Golden-Faelle.

Der Waechter ist gegen einen eingefuegten Verstoss geprueft worden, nicht nur gegen den sauberen Stand: eine Tabellenzeile mit MAJOR und ein "F7" ergeben zwei Befunde und exit 1. Dasselbe fuer die neue Tag-Pruefung, ein verstellter Pin in `docs/ci-example.yml` faellt auf.

Packaging und Release-Pfad sind unberuehrt: `package-skill.py` und `check-package.py` laufen durch, zwei Baeufe hintereinander ergeben dieselbe Datei Byte fuer Byte, und `check-version.py --tag v3.2.0`, der Schritt des Release-Workflows, ist gruen. `cli/`, `evals/`, `tests/` und alle `.py` stehen jetzt in den verbotenen Mustern der Paketpruefung; im Artefakt sind sie nicht.

Zwei falsche Aussagen sind nebenbei korrigiert worden: die Roadmap behauptete, der Tag `v3.2.0` sei nicht gesetzt, und die Grenzen-Liste datierte die Umstellung auf eine Version, die es noch nicht gibt.

### Was bewusst offen bleibt

**Ebene 2 der Eval-Suite.** Dieselben Faelle durch die Claude-API zu schicken waere der Beleg, dass Skill-Prosa und Linter dasselbe sagen. Ein Lauf gegen ein Sprachmodell ist aber nicht reproduzierbar, kostet Budget und braucht ein Secret. Er gehoert in einen eigenen Workflow, nicht in die Pipeline bei jedem Push. Damit fehlt auch der Cross-Artifact-Fall "plan.md widerspricht der spec.md beim NFR": mit Regex ist er nicht deterministisch pruefbar.

**Die Composite Action ist noch nicht per Tag nutzbar.** `.github/actions/specforge-check/` liegt auf diesem Branch, im Release `v3.2.0` gibt es sie nicht. `docs/ci-example.yml` nennt den Vorbehalt und den Zwischenweg ueber einen eigenen Checkout; `check-version.py` haelt den Pin an der Versionsquelle, damit er beim naechsten Release mitwandert.

**Drei Folgearbeiten aus derselben Analyse.** `05-checklist.md` erzeugt weiterhin Checklisten ohne Schweregrad-Angabe. `@dora` weicht als Referenzimplementierung noch vom eigenen Schema ab (Spaltenname `DORA-Artikel` statt `Rechtsquelle`, kein `_default` in der Checkliste, `F 4` mit Leerzeichen, F-Stufen-Tabelle doppelt gepflegt). `kritis-nfr.md` hat keine Rechtsquellen-Spalte und fuehrt ihre F-Stufen ueber das Profil, waehrend die Extensions das ueber die Perspektive tun. Der dritte Punkt ist keine Redaktion, sondern eine Entscheidung ueber zwei Achsen und braucht eigene Ueberlegung.

**Version und CHANGELOG sind nicht angefasst.** Der Bump gehoert zum Release, nicht zum Feature-Branch.

Aufgefallen und dokumentiert, aber nicht behoben: das Kategorie-Kuerzel `IRM` gibt es in `@dora` und `@bait` mit verschiedener Bedeutung und verschiedenen Stufen. Sind beide aktiv, gilt im Linter die Vereinigung ihrer Stufen. Das Schema in `CONTRIBUTING-CHECKLISTS.md` kennt keine Eindeutigkeit ueber Paketgrenzen hinweg; bei der naechsten Extension faellt das wieder auf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL7UoPomBp2Luhg89R6fYk

## Wie dieser Branch entstanden ist

Vier Durchgaenge, jeder mit eigener Abnahme, die selbst gemessen hat statt Berichte zu glauben.

1. Umsetzung der Welle-5-Aufgaben.
2. Die Abnahme fand in allen sieben Repos Befunde und gab keinen einzigen frei. Der wiederkehrende
   Typ: eine Sicherheitsaussage in der Doku, die eine Messung widerlegt, und ein Gate, das
   durchlaesst, sobald jemand das richtige Wort hinschreibt.
3. Nacharbeit, danach eine zweite Abnahme. Sie fand, dass die Nacharbeit an mehreren Stellen neue
   Probleme eingebaut hatte, darunter eine echte Erkennungsregression.
4. Letzte Runde, streng auf Blocker und Regressionen begrenzt, mit der Vorgabe: wo sich eine
   Aenderung nicht sauber reparieren laesst, wird sie zurueckgebaut. Gemessen wurde gegen den Stand
   von `main`, nicht gegen den eigenen Zwischenstand.

## Gepruefte Abnahmekriterien

Vor dem Oeffnen dieses Pull Requests wurde am Branch nachgemessen:

- alle CI-Schritte aus `.github/workflows/ci.yml` laufen lokal durch
- das Packaging-Skript baut das Release-Artefakt, und der Paketpruefer nimmt es an
- der Arbeitsbaum ist sauber, im Diff stehen keine Zugangsdaten und keine Personendaten

Was offen bleibt, steht in der Beschreibung darueber. Es ist bewusst offen und nicht uebersehen.


---
**Gestapelt.** Dieser PR sitzt auf `main`. GitHub haengt ihn automatisch auf `main` um, sobald der darunterliegende PR gemergt ist. Vorher zeigt der Diff nur die Welle-3-Aenderungen, das ist so gewollt.

Teil von Welle 5 des Haerteplans: Sicherheitshaerte. Jede Aenderung wurde von einem zweiten Durchgang abgenommen, der das Artefakt selbst gebaut, entpackt und den Installationsweg durchgegangen ist.
